### PR TITLE
VMC-282: Add external message prefix for prompt injection mitigation

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -195,6 +195,8 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
 // Push a channel notification for an inbound voice event
 // ---------------------------------------------------------------------------
 
+const EXTERNAL_MESSAGE_PREFIX = '[VoiceMode Connect - External Message]: '
+
 async function push_voice_event(
   caller: string,
   transcript: string,
@@ -208,7 +210,7 @@ async function push_voice_event(
   await mcp.notification({
     method: 'notifications/claude/channel',
     params: {
-      content: transcript,
+      content: `${EXTERNAL_MESSAGE_PREFIX}${transcript}`,
       meta,
     },
   })


### PR DESCRIPTION
## Summary
- Prefix channel-delivered messages with `[VoiceMode Connect - External Message]:` 
- Mitigates prompt injection by marking messages as external/untrusted
- Claude Code can treat prefixed messages with appropriate skepticism
- Critical finding from kito security review (VMC-106)

## Test plan
- [x] Build passes
- [ ] Verify prefix appears in Claude Code when receiving Connect messages
- [ ] Verify system/protocol messages are not prefixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>