### PR TITLE
feat(VMC-298): add profile MCP tool for agent identity

### DIFF
--- a/gateway.ts
+++ b/gateway.ts
@@ -22,6 +22,18 @@ import { join, basename } from 'node:path'
 import { EventEmitter } from 'node:events'
 
 // ---------------------------------------------------------------------------
+// Profile data type (shared with index.ts)
+// ---------------------------------------------------------------------------
+
+export interface ProfileData {
+  name: string
+  display_name: string
+  context: string | null
+  voice: string | null
+  presence: string
+}
+
+// ---------------------------------------------------------------------------
 // Configuration
 // ---------------------------------------------------------------------------
 
@@ -44,7 +56,7 @@ const MAX_RETRY_DELAY_MS = 60_000
  * Returns the git remote origin basename (e.g., "voicemode-connect") or
  * the directory name as fallback. Returns null if detection fails.
  */
-function get_project_context(cwd: string): string | null {
+export function get_project_context(cwd: string): string | null {
   try {
     // Try git remote origin URL first (most specific)
     const remote_url = execSync('git remote get-url origin 2>/dev/null', { cwd, encoding: 'utf8' }).trim()
@@ -197,6 +209,7 @@ export class GatewayClient extends EventEmitter {
   private _reconnect_count = 0
   private _shutting_down = false
   private _log: (msg: string) => void
+  private _profile: ProfileData | undefined
 
   constructor(log_fn: (msg: string) => void) {
     super()
@@ -236,6 +249,16 @@ export class GatewayClient extends EventEmitter {
     }
     this._ws.send(JSON.stringify(msg))
     return true
+  }
+
+  /**
+   * Send a capabilities_update with the given profile data.
+   * Called by the channel server when the profile tool updates fields.
+   * Stores the profile so reconnects use the latest values.
+   */
+  send_capabilities_update(profile: ProfileData): void {
+    this._profile = profile
+    this._send_capabilities_update(profile)
   }
 
   /**
@@ -324,9 +347,9 @@ export class GatewayClient extends EventEmitter {
           this._session_id = ((msg.sessionId as string) ?? '').slice(0, 12)
           this._log(`Authenticated (session: ${this._session_id})`)
 
-          // Send ready message, then announce as callable agent
+          // Send ready message; capabilities_update is sent by the
+          // channel server via the 'connected' event handler.
           this._send_ready()
-          this._send_capabilities_update()
 
           // Start heartbeat
           this._start_heartbeat()
@@ -391,25 +414,32 @@ export class GatewayClient extends EventEmitter {
    * Send capabilities_update to register as a callable agent.
    * This is how the gateway knows this connection can receive voice messages.
    * Without this, the connection won't show up in the users/contacts list.
+   *
+   * Accepts profile data from the channel server so that profile tool updates
+   * are reflected immediately without restarting.
    */
-  private _send_capabilities_update(): void {
+  private _send_capabilities_update(profile?: ProfileData): void {
     if (!this._ws || this._ws.readyState !== WebSocket.OPEN) return
 
-    const agent_name = process.env.VOICEMODE_AGENT_NAME ?? 'voicemode'
-    const display_name = process.env.VOICEMODE_AGENT_DISPLAY_NAME ?? 'Claude Code'
+    const agent_name = profile?.name ?? process.env.VOICEMODE_AGENT_NAME ?? 'voicemode'
+    const display_name = profile?.display_name ?? process.env.VOICEMODE_AGENT_DISPLAY_NAME ?? 'Claude Code'
+    const presence = profile?.presence ?? 'available'
     const host = hostname()
     const project_path = process.cwd()
-    const context = get_project_context(project_path)
+    const context = profile?.context ?? get_project_context(project_path)
 
     const user_entry: Record<string, unknown> = {
       name: agent_name,
       host,
       display_name,
-      presence: 'available',
+      presence,
       project_path,
     }
     if (context) {
       user_entry.context = context
+    }
+    if (profile?.voice) {
+      user_entry.voice = profile.voice
     }
 
     const capabilities_msg = {
@@ -419,7 +449,7 @@ export class GatewayClient extends EventEmitter {
     }
 
     this._ws.send(JSON.stringify(capabilities_msg))
-    this._log(`Sent capabilities_update: agent="${agent_name}" display="${display_name}" host="${host}" context="${context ?? project_path}"`)
+    this._log(`Sent capabilities_update: agent="${agent_name}" display="${display_name}" host="${host}" context="${context ?? project_path}" presence="${presence}"`)
   }
 
   private _start_heartbeat(): void {

--- a/index.ts
+++ b/index.ts
@@ -23,7 +23,8 @@ import { appendFileSync, mkdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { randomBytes } from 'node:crypto'
-import { GatewayClient } from './gateway.js'
+import { GatewayClient, get_project_context } from './gateway.js'
+import type { ProfileData } from './gateway.js'
 
 // ---------------------------------------------------------------------------
 // Load ~/.voicemode/voicemode.env (simple dotenv parsing)
@@ -72,6 +73,18 @@ const INSTRUCTIONS = [
   'Address the caller by name.',
   'Keep responses concise -- the user is listening via text-to-speech.',
 ].join(' ')
+
+// ---------------------------------------------------------------------------
+// Agent profile state (mutable via the profile tool)
+// ---------------------------------------------------------------------------
+
+let currentProfile: ProfileData = {
+  name: process.env.VOICEMODE_AGENT_NAME ?? 'voicemode',
+  display_name: process.env.VOICEMODE_AGENT_DISPLAY_NAME ?? 'Claude Code',
+  context: get_project_context(process.cwd()),
+  voice: null,
+  presence: 'available',
+}
 
 // ---------------------------------------------------------------------------
 // MCP server with channel capability
@@ -128,6 +141,39 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => {
           required: ['text'],
         },
       },
+      {
+        name: 'profile',
+        description:
+          'Get or update the agent profile. ' +
+          'Call with no arguments to read the current profile. ' +
+          'Call with fields to update them and push a capabilities_update to the gateway.',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            name: {
+              type: 'string',
+              description: 'Agent identity (e.g. "cora")',
+            },
+            display_name: {
+              type: 'string',
+              description: 'Human-readable name (e.g. "Cora 7")',
+            },
+            context: {
+              type: 'string',
+              description: 'What the agent is working on (e.g. "voicemode-connect", "VMC-298")',
+            },
+            voice: {
+              type: 'string',
+              description: 'Preferred TTS voice',
+            },
+            presence: {
+              type: 'string',
+              description: 'Agent presence status',
+              enum: ['available', 'busy', 'away'],
+            },
+          },
+        },
+      },
     ],
   }
 })
@@ -135,15 +181,27 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => {
 mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params
 
-  if (name !== 'reply') {
-    return {
-      content: [{ type: 'text', text: `Unknown tool: ${name}` }],
-      isError: true,
-    }
+  if (name === 'profile') {
+    return handle_profile_tool(args as Record<string, unknown> | undefined)
   }
 
+  if (name === 'reply') {
+    return handle_reply_tool(args as Record<string, unknown> | undefined)
+  }
+
+  return {
+    content: [{ type: 'text', text: `Unknown tool: ${name}` }],
+    isError: true,
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Tool handler: reply
+// ---------------------------------------------------------------------------
+
+function handle_reply_tool(args: Record<string, unknown> | undefined) {
   // Validate arguments
-  const text = (args as Record<string, unknown>)?.text
+  const text = args?.text
   if (typeof text !== 'string' || text.trim().length === 0) {
     return {
       content: [{ type: 'text', text: 'Error: text parameter is required and must be non-empty' }],
@@ -151,8 +209,8 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
     }
   }
 
-  const voice = (args as Record<string, unknown>)?.voice as string | undefined
-  const wait_for_response = (args as Record<string, unknown>)?.wait_for_response as boolean | undefined
+  const voice = args?.voice as string | undefined
+  const wait_for_response = args?.wait_for_response as boolean | undefined
 
   // Check gateway connection
   if (!gateway || gateway.state !== 'connected') {
@@ -189,7 +247,46 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
       text: `Reply sent (id: ${msg_id}). Text: "${truncate(text.trim(), 120)}"`,
     }],
   }
-})
+}
+
+// ---------------------------------------------------------------------------
+// Tool handler: profile
+// ---------------------------------------------------------------------------
+
+function handle_profile_tool(args: Record<string, unknown> | undefined) {
+  // No args (or empty object) -- return current profile
+  const has_updates = args && Object.keys(args).length > 0
+  if (!has_updates) {
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify(currentProfile, null, 2),
+      }],
+    }
+  }
+
+  // Merge provided fields into current profile
+  if (typeof args.name === 'string') currentProfile.name = args.name
+  if (typeof args.display_name === 'string') currentProfile.display_name = args.display_name
+  if (typeof args.context === 'string') currentProfile.context = args.context
+  if (typeof args.voice === 'string') currentProfile.voice = args.voice
+  if (typeof args.presence === 'string') currentProfile.presence = args.presence
+
+  log(`Profile updated: ${JSON.stringify(currentProfile)}`)
+
+  // Push capabilities update to the gateway if connected
+  if (gateway && gateway.state === 'connected') {
+    gateway.send_capabilities_update(currentProfile)
+    log('Pushed capabilities_update after profile change')
+  }
+
+  return {
+    content: [{
+      type: 'text',
+      text: JSON.stringify(currentProfile, null, 2),
+    }],
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Push a channel notification for an inbound voice event
@@ -255,6 +352,9 @@ function start_gateway(): void {
 
   gateway.on('connected', () => {
     log('Gateway connection established -- ready to receive voice events')
+    // Push current profile to the gateway on every (re)connect so the
+    // gateway always has the latest profile state.
+    gateway!.send_capabilities_update(currentProfile)
   })
 
   gateway.on('disconnected', () => {


### PR DESCRIPTION
## Summary

- Add `profile` tool to the MCP channel server that supports get/set of agent identity fields (`name`, `display_name`, `context`, `voice`, `presence`)
- Calling with no args returns the current profile as JSON; calling with fields merges updates and pushes a `capabilities_update` to the gateway
- Export `ProfileData` interface and `get_project_context()` from gateway.ts; add public `send_capabilities_update(profile)` method to `GatewayClient`
- Refactor `CallToolRequestSchema` handler into separate `handle_reply_tool` and `handle_profile_tool` functions

## Test plan

- [ ] Start channel server, verify `profile` tool appears in tool list alongside `reply`
- [ ] Call `profile` with no args -- should return current profile JSON with defaults from env vars
- [ ] Call `profile` with `{ "name": "cora", "display_name": "Cora 7", "presence": "busy" }` -- should update and return merged profile
- [ ] Verify `capabilities_update` is sent to gateway after profile update (check channel.log)
- [ ] Verify `reply` tool still works as before
- [ ] `npx tsc --noEmit` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)