### PR TITLE
feat(VMC-300): generate session_id in capabilities_update

### DIFF
--- a/gateway.ts
+++ b/gateway.ts
@@ -14,6 +14,7 @@
  */
 
 import WebSocket from 'ws'
+import { randomUUID } from 'node:crypto'
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
 import { execSync } from 'node:child_process'
 import { homedir } from 'node:os'
@@ -204,6 +205,7 @@ export class GatewayClient extends EventEmitter {
   private _ws: WebSocket | null = null
   private _state: GatewayState = 'disconnected'
   private _session_id: string | null = null
+  private readonly _agent_session_id: string = process.env.CLAUDE_SESSION_ID ?? randomUUID()
   private _heartbeat_timer: ReturnType<typeof setInterval> | null = null
   private _retry_delay_ms = INITIAL_RETRY_DELAY_MS
   private _reconnect_count = 0
@@ -222,6 +224,10 @@ export class GatewayClient extends EventEmitter {
 
   get session_id(): string | null {
     return this._session_id
+  }
+
+  get agent_session_id(): string {
+    return this._agent_session_id
   }
 
   // -----------------------------------------------------------------------
@@ -445,11 +451,12 @@ export class GatewayClient extends EventEmitter {
     const capabilities_msg = {
       type: 'capabilities_update',
       platform: 'claude-code',
+      session_id: this._agent_session_id,
       users: [user_entry],
     }
 
     this._ws.send(JSON.stringify(capabilities_msg))
-    this._log(`Sent capabilities_update: agent="${agent_name}" display="${display_name}" host="${host}" context="${context ?? project_path}" presence="${presence}"`)
+    this._log(`Sent capabilities_update: session="${this._agent_session_id}" agent="${agent_name}" display="${display_name}" host="${host}" context="${context ?? project_path}" presence="${presence}"`)
   }
 
   private _start_heartbeat(): void {


### PR DESCRIPTION
## Summary

- Channel server generates a stable UUID (`agent_session_id`) at process startup
- Included as `session_id` field in `capabilities_update` messages to gateway
- Uses `CLAUDE_SESSION_ID` env var if available (from launcher), otherwise `randomUUID()`
- Stable across WebSocket reconnects (same process = same session_id)

## Changes

**gateway.ts** (+8 lines)
- Import `randomUUID` from `node:crypto`
- New `_agent_session_id` field (readonly, generated once at class instantiation)
- Public `agent_session_id` getter
- `session_id` field added to capabilities_update message
- Session ID included in log output

## Note

The existing `_session_id` field is NOT modified -- it stores the gateway's WebSocket session token (different concept). The new `_agent_session_id` is the process-level identity for VMC-300.

## Test plan

- [x] TypeScript compiles clean
- [ ] Verify session_id appears in capabilities_update (check gateway logs)
- [ ] Verify session_id is stable across reconnects

🤖 Generated with [Claude Code](https://claude.com/claude-code)