### PR TITLE
Pre-public release hardening (VMCH-2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 !start.sh
 .DS_Store
 package-lock.json
+.voicemode.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ All notable changes to the VoiceMode Channel plugin will be documented in this f
 
 ## [0.1.4] - 2026-03-24
 
-## [0.1.3] - 2026-03-24
+### Added
+- Session ID (`session_id`) included in `capabilities_update` for multi-session coexistence
+
+### Fixed
+- **Security:** Replace `execSync` with `execFileSync` in `get_project_context` -- eliminates shell injection surface
+- **Security:** Add WebSocket `maxPayload` limit (1 MB) -- prevents memory exhaustion from oversized payloads
+- **Reliability:** Heartbeat liveness detection -- force-close WebSocket after 60s silence, triggers reconnect
+- **Reliability:** Guard against concurrent `start()` calls; cancellable backoff sleep for prompt shutdown
 
 ## [0.1.3] - 2026-03-24
 
@@ -25,6 +32,10 @@ All notable changes to the VoiceMode Channel plugin will be documented in this f
 - Refactored tool handlers into separate functions (handle_reply_tool, handle_profile_tool)
 
 ## [0.1.2] - 2026-03-23
+
+### Added
+- External message prefix on channel-delivered transcripts -- prompt injection mitigation
+- Load `voicemode.env` for config; fix plugin path resolution
 
 ## [0.1.1] - 2026-03-23
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ claude plugin install voicemode-channel@mbailey
 
 - Node.js 20+
 - VoiceMode Connect credentials (`~/.voicemode/credentials`)
-  - Run `voicemode connect login` to authenticate
+  - Run `voicemode connect auth login` to authenticate
 
 ## Usage
 
@@ -58,6 +58,26 @@ Channel events appear in Claude's session as:
 ```
 <channel source="voicemode-channel" caller="NAME">TRANSCRIPT</channel>
 ```
+
+## Troubleshooting
+
+**Channel not connecting**
+- Ensure `VOICEMODE_CHANNEL_ENABLED=true` is set
+- Check credentials exist: `~/.voicemode/credentials`
+- Re-authenticate: `voicemode connect auth login`
+- Enable debug logging: `VOICEMODE_CHANNEL_DEBUG=true`
+
+**No audio on caller's device**
+- Confirm you're signed into [app.voicemode.dev](https://app.voicemode.dev) with the same account
+- Check that Claude is using the `reply` tool (not a plain text response)
+
+**Plugin not found after install**
+- Verify Claude Code v2.1.80+ is installed: `claude --version`
+- Reinstall: `claude plugin install voicemode-channel@mbailey`
+
+**Hook timeout on startup**
+- The SessionStart hook installs npm dependencies — this may take a moment on first run
+- Subsequent starts use the cached install and are fast
 
 ## Development
 

--- a/gateway.ts
+++ b/gateway.ts
@@ -456,7 +456,6 @@ export class GatewayClient extends EventEmitter {
       host,
       display_name,
       presence,
-      project_path,
     }
     if (context) {
       user_entry.context = context

--- a/gateway.ts
+++ b/gateway.ts
@@ -424,7 +424,7 @@ export class GatewayClient extends EventEmitter {
       type: 'ready',
       device: {
         platform: 'channel-server',
-        appVersion: '0.1.0',
+        appVersion: '0.1.4',
         name: `channel@${hostname()}`,
       },
     }

--- a/gateway.ts
+++ b/gateway.ts
@@ -213,6 +213,9 @@ export class GatewayClient extends EventEmitter {
   private _retry_delay_ms = INITIAL_RETRY_DELAY_MS
   private _reconnect_count = 0
   private _shutting_down = false
+  private _running = false
+  private _sleep_resolve: (() => void) | null = null
+  private _sleep_timer: ReturnType<typeof setTimeout> | null = null
   private _log: (msg: string) => void
   private _profile: ProfileData | undefined
 
@@ -243,6 +246,8 @@ export class GatewayClient extends EventEmitter {
    */
   async start(): Promise<void> {
     if (this._shutting_down) return
+    if (this._running) return
+    this._running = true
     this._set_state('connecting')
     this._connection_loop()
   }
@@ -275,6 +280,7 @@ export class GatewayClient extends EventEmitter {
    */
   async shutdown(): Promise<void> {
     this._shutting_down = true
+    this._cancel_sleep()
     this._stop_heartbeat()
     if (this._ws) {
       try {
@@ -293,21 +299,25 @@ export class GatewayClient extends EventEmitter {
   // -----------------------------------------------------------------------
 
   private async _connection_loop(): Promise<void> {
-    while (!this._shutting_down) {
-      try {
-        await this._connect_once()
-      } catch {
-        // Error handled inside _connect_once
+    try {
+      while (!this._shutting_down) {
+        try {
+          await this._connect_once()
+        } catch {
+          // Error handled inside _connect_once
+        }
+
+        if (this._shutting_down) break
+
+        // Reconnect with exponential backoff
+        this._reconnect_count++
+        this._set_state('reconnecting')
+        this._log(`Reconnecting in ${this._retry_delay_ms / 1000}s (attempt ${this._reconnect_count})...`)
+        await this._sleep(this._retry_delay_ms)
+        this._retry_delay_ms = Math.min(this._retry_delay_ms * 2, MAX_RETRY_DELAY_MS)
       }
-
-      if (this._shutting_down) break
-
-      // Reconnect with exponential backoff
-      this._reconnect_count++
-      this._set_state('reconnecting')
-      this._log(`Reconnecting in ${this._retry_delay_ms / 1000}s (attempt ${this._reconnect_count})...`)
-      await this._sleep(this._retry_delay_ms)
-      this._retry_delay_ms = Math.min(this._retry_delay_ms * 2, MAX_RETRY_DELAY_MS)
+    } finally {
+      this._running = false
     }
   }
 
@@ -503,12 +513,24 @@ export class GatewayClient extends EventEmitter {
 
   private _sleep(ms: number): Promise<void> {
     return new Promise((resolve) => {
-      const timer = setTimeout(resolve, ms)
-      // Allow the timer to not keep the process alive during shutdown
-      if (this._shutting_down) {
-        clearTimeout(timer)
+      this._sleep_resolve = resolve
+      this._sleep_timer = setTimeout(() => {
+        this._sleep_resolve = null
+        this._sleep_timer = null
         resolve()
-      }
+      }, ms)
     })
+  }
+
+  private _cancel_sleep(): void {
+    if (this._sleep_timer !== null) {
+      clearTimeout(this._sleep_timer)
+      this._sleep_timer = null
+    }
+    if (this._sleep_resolve !== null) {
+      const resolve = this._sleep_resolve
+      this._sleep_resolve = null
+      resolve()
+    }
   }
 }

--- a/gateway.ts
+++ b/gateway.ts
@@ -45,6 +45,7 @@ const CREDENTIALS_FILE = join(homedir(), '.voicemode', 'credentials')
 const TOKEN_EXPIRY_BUFFER_SECONDS = 60
 
 const HEARTBEAT_INTERVAL_MS = 25_000
+const HEARTBEAT_LIVENESS_TIMEOUT_MS = 60_000 // Force-close if no pong received within this window
 const INITIAL_RETRY_DELAY_MS = 1_000
 const MAX_RETRY_DELAY_MS = 60_000
 const MAX_PAYLOAD_BYTES = 1_048_576 // 1 MB -- reject oversized messages to prevent memory exhaustion
@@ -208,6 +209,7 @@ export class GatewayClient extends EventEmitter {
   private _session_id: string | null = null
   private readonly _agent_session_id: string = process.env.CLAUDE_SESSION_ID ?? randomUUID()
   private _heartbeat_timer: ReturnType<typeof setInterval> | null = null
+  private _last_pong_at = 0
   private _retry_delay_ms = INITIAL_RETRY_DELAY_MS
   private _reconnect_count = 0
   private _shutting_down = false
@@ -337,8 +339,11 @@ export class GatewayClient extends EventEmitter {
       ws.on('message', (data: WebSocket.Data) => {
         const raw = data.toString()
 
-        // Ignore auto-response pong messages
-        if (raw === 'pong') return
+        // Ignore auto-response pong messages -- record timestamp for liveness detection
+        if (raw === 'pong') {
+          this._last_pong_at = Date.now()
+          return
+        }
 
         let msg: Record<string, unknown>
         try {
@@ -369,7 +374,7 @@ export class GatewayClient extends EventEmitter {
           this._set_state('connected')
           this.emit('connected')
         } else if (msg_type === 'heartbeat_ack' || msg_type === 'heartbeat') {
-          // Silently handle heartbeat responses
+          this._last_pong_at = Date.now()
         } else if (msg_type === 'error') {
           const error_msg = (msg.message as string) ?? 'Unknown error'
           const error_code = (msg.code as string) ?? ''
@@ -463,8 +468,16 @@ export class GatewayClient extends EventEmitter {
 
   private _start_heartbeat(): void {
     this._stop_heartbeat()
+    this._last_pong_at = Date.now()
     this._heartbeat_timer = setInterval(() => {
       if (this._ws && this._ws.readyState === WebSocket.OPEN) {
+        // Check liveness -- if no pong received within timeout, force-close (half-open TCP)
+        const silent_ms = Date.now() - this._last_pong_at
+        if (silent_ms > HEARTBEAT_LIVENESS_TIMEOUT_MS) {
+          this._log(`No heartbeat response in ${Math.round(silent_ms / 1000)}s -- force-closing (half-open TCP suspected)`)
+          this._ws.terminate()
+          return
+        }
         // Send literal "ping" text -- auto-responded by DO runtime without waking it
         this._ws.send('ping')
       }

--- a/gateway.ts
+++ b/gateway.ts
@@ -31,7 +31,7 @@ export interface ProfileData {
   display_name: string
   context: string | null
   voice: string | null
-  presence: string
+  presence: 'available' | 'busy' | 'away'
 }
 
 // ---------------------------------------------------------------------------

--- a/gateway.ts
+++ b/gateway.ts
@@ -16,7 +16,7 @@
 import WebSocket from 'ws'
 import { randomUUID } from 'node:crypto'
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
-import { execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import { homedir } from 'node:os'
 import { hostname } from 'node:os'
 import { join, basename } from 'node:path'
@@ -60,7 +60,7 @@ const MAX_RETRY_DELAY_MS = 60_000
 export function get_project_context(cwd: string): string | null {
   try {
     // Try git remote origin URL first (most specific)
-    const remote_url = execSync('git remote get-url origin 2>/dev/null', { cwd, encoding: 'utf8' }).trim()
+    const remote_url = execFileSync('git', ['remote', 'get-url', 'origin'], { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim()
     if (remote_url) {
       // Extract repo name from URL: https://github.com/user/repo.git -> repo
       const repo_name = basename(remote_url).replace(/\.git$/, '')

--- a/gateway.ts
+++ b/gateway.ts
@@ -47,6 +47,7 @@ const TOKEN_EXPIRY_BUFFER_SECONDS = 60
 const HEARTBEAT_INTERVAL_MS = 25_000
 const INITIAL_RETRY_DELAY_MS = 1_000
 const MAX_RETRY_DELAY_MS = 60_000
+const MAX_PAYLOAD_BYTES = 1_048_576 // 1 MB -- reject oversized messages to prevent memory exhaustion
 
 // ---------------------------------------------------------------------------
 // Project context helpers
@@ -323,6 +324,7 @@ export class GatewayClient extends EventEmitter {
     return new Promise<void>((resolve, reject) => {
       const ws = new WebSocket(WS_URL, {
         headers: { Authorization: `Bearer ${token}` },
+        maxPayload: MAX_PAYLOAD_BYTES,
       })
 
       let authenticated = false

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -2,6 +2,7 @@
   "hooks": {
     "SessionStart": [
       {
+        "timeout": 30000,
         "hooks": [
           {
             "type": "command",

--- a/index.ts
+++ b/index.ts
@@ -209,8 +209,8 @@ function handle_reply_tool(args: Record<string, unknown> | undefined) {
     }
   }
 
-  const voice = args?.voice as string | undefined
-  const wait_for_response = args?.wait_for_response as boolean | undefined
+  const voice = typeof args?.voice === 'string' ? args.voice : undefined
+  const wait_for_response = typeof args?.wait_for_response === 'boolean' ? args.wait_for_response : undefined
 
   // Check gateway connection
   if (!gateway || gateway.state !== 'connected') {
@@ -270,7 +270,7 @@ function handle_profile_tool(args: Record<string, unknown> | undefined) {
   if (typeof args.display_name === 'string') currentProfile.display_name = args.display_name
   if (typeof args.context === 'string') currentProfile.context = args.context
   if (typeof args.voice === 'string') currentProfile.voice = args.voice
-  if (typeof args.presence === 'string') currentProfile.presence = args.presence
+  if (args.presence === 'available' || args.presence === 'busy' || args.presence === 'away') currentProfile.presence = args.presence
 
   log(`Profile updated: ${JSON.stringify(currentProfile)}`)
 

--- a/index.ts
+++ b/index.ts
@@ -382,6 +382,12 @@ function start_gateway(): void {
       return
     }
 
+    const MAX_TRANSCRIPT_LENGTH = 10000
+    if (text.length > MAX_TRANSCRIPT_LENGTH) {
+      log(`Truncating transcript from ${text.length} to ${MAX_TRANSCRIPT_LENGTH} chars`)
+    }
+    const safe_text = text.slice(0, MAX_TRANSCRIPT_LENGTH)
+
     // Caller identity: use "from" field if available, fall back to userId
     const caller = typeof from === 'string' && from.length > 0
       ? from
@@ -394,9 +400,9 @@ function start_gateway(): void {
       ? user_id
       : undefined
 
-    log(`Received voice event: from="${caller}" text="${truncate(text.trim(), 80)}"`)
+    log(`Received voice event: from="${caller}" text="${truncate(safe_text.trim(), 80)}"`)
 
-    push_voice_event(caller, text.trim(), device_id).catch((err: unknown) => {
+    push_voice_event(caller, safe_text.trim(), device_id).catch((err: unknown) => {
       const message = err instanceof Error ? err.message : String(err)
       log(`Error pushing voice event to channel: ${message}`)
     })

--- a/index.ts
+++ b/index.ts
@@ -62,7 +62,7 @@ if (process.env.VOICEMODE_CHANNEL_ENABLED !== 'true') {
 }
 
 const CHANNEL_NAME = 'voicemode-channel'
-const CHANNEL_VERSION = '0.1.0'
+const CHANNEL_VERSION = '0.1.4'
 
 const INSTRUCTIONS = [
   'Events from VoiceMode appear as <channel source="voicemode-channel" caller="NAME">TRANSCRIPT</channel>.',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voicemode-channel",
-  "version": "0.1.0",
+  "version": "0.1.4",
   "description": "VoiceMode Channel - inbound voice calls to Claude Code via VoiceMode Connect",
   "type": "module",
   "dependencies": {

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 # Start the VoiceMode channel server
 # When loaded as a plugin: CLAUDE_PLUGIN_ROOT and CLAUDE_PLUGIN_DATA are set by Claude Code
 # When running from the repo: falls back to script directory


### PR DESCRIPTION
## Summary

Comprehensive pre-public-release hardening based on four parallel reviews (security, reliability, code quality, plugin structure).

- **Security**: Replace `execSync` with `execFileSync`, add WebSocket `maxPayload` (1MB), add transcript length limit, remove `project_path` from gateway
- **Reliability**: Heartbeat liveness detection (force-close on 60s silence), guard against concurrent `start()`, cancellable sleep on shutdown
- **Quality**: Sync versions to 0.1.4, fix changelog, tighten TypeScript types, add `.voicemode.env` to gitignore
- **Plugin**: Add `set -e` to start.sh, hook timeout (30s), fix README commands, add troubleshooting section

8 files changed, 111 insertions, 35 deletions.

## Test plan

- [ ] Plugin loads and connects to gateway
- [ ] Voice call end-to-end (speak → transcribe → reply → TTS)
- [ ] Verify reconnection after network drop
- [ ] Verify shutdown completes promptly (no 60s hang)
- [ ] TypeScript compiles clean (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)