### PR TITLE
fix: include project_path in capabilities_update (VMC-302)

### DIFF
--- a/gateway.ts
+++ b/gateway.ts
@@ -456,6 +456,7 @@ export class GatewayClient extends EventEmitter {
       host,
       display_name,
       presence,
+      project_path,
     }
     if (context) {
       user_entry.context = context


### PR DESCRIPTION
## Summary

- **Root cause**: Channel plugin computed `project_path = process.cwd()` but never included it in the capabilities_update user entry
- **Impact**: Gateway derived deviceId from `host:project_path`, but with `project_path` undefined, ALL agents on the same host got deviceId = just hostname (e.g. `mba.local`)
- **Result**: VMD-200 device bumping treated every agent on the same machine as the "same device" and closed old connections, creating infinite reconnect loops between agents

**Fix**: Add `project_path` to the user entry so the gateway can derive unique deviceIds per project directory.

Companion PR in voicemode-connect adds a gateway-side fix for agents in the *same* directory.

## Test plan

- [ ] Deploy both PRs
- [ ] Run two agents on the same machine in different directories -- verify both stay connected
- [ ] Run two agents on the same machine in the same directory -- verify both stay connected (needs gateway fix too)
- [ ] Check receiver console for absence of "Connection takeover" messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)