### PR TITLE
feat: publish voicemode-channel to npm (VMC-450)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/README.md
+++ b/README.md
@@ -14,15 +14,39 @@ User hears TTS response  <- Channel reply tool <----------------------+
 
 ## Install
 
+### Claude Code plugin
+
 ```bash
 claude plugin install voicemode-channel@mbailey
+```
+
+### Standalone (any MCP host)
+
+```bash
+npx voicemode-channel
 ```
 
 ## Prerequisites
 
 - Node.js 20+
 - VoiceMode Connect credentials (`~/.voicemode/credentials`)
-  - Run `voicemode connect auth login` to authenticate
+  - Run `voicemode-channel auth login` to authenticate
+
+## Auth
+
+Manage your VoiceMode Connect credentials:
+
+```bash
+voicemode-channel auth login    # Authenticate via browser (PKCE flow)
+voicemode-channel auth logout   # Remove stored credentials
+voicemode-channel auth status   # Show current auth state
+```
+
+Or via npx:
+
+```bash
+npx voicemode-channel auth login
+```
 
 ## Usage
 
@@ -65,8 +89,8 @@ Channel events appear in Claude's session as:
 
 **Channel not connecting**
 - Ensure `VOICEMODE_CHANNEL_ENABLED=true` is set
-- Check credentials exist: `~/.voicemode/credentials`
-- Re-authenticate: `voicemode connect auth login`
+- Check credentials exist: `voicemode-channel auth status`
+- Re-authenticate: `voicemode-channel auth login`
 - Enable debug logging: `VOICEMODE_CHANNEL_DEBUG=true`
 
 **No audio on caller's device**
@@ -78,7 +102,7 @@ Channel events appear in Claude's session as:
 - Reinstall: `claude plugin install voicemode-channel@mbailey`
 
 **Hook timeout on startup**
-- The SessionStart hook installs npm dependencies — this may take a moment on first run
+- The SessionStart hook installs npm dependencies -- this may take a moment on first run
 - Subsequent starts use the cached install and are fast
 
 ## Development
@@ -88,6 +112,9 @@ Channel events appear in Claude's session as:
 git clone https://github.com/mbailey/voicemode-channel.git
 cd voicemode-channel
 npm install
+
+# Build
+npm run build
 
 # Test with --plugin-dir
 VOICEMODE_CHANNEL_ENABLED=true claude --plugin-dir . --dangerously-load-development-channels server:voicemode-channel

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx tsx
+#!/usr/bin/env node
 /**
  * VoiceMode Channel Server
  *

--- a/package.json
+++ b/package.json
@@ -3,14 +3,26 @@
   "version": "0.1.4",
   "description": "VoiceMode Channel - inbound voice calls to Claude Code via VoiceMode Connect",
   "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "voicemode-channel": "dist/index.js"
+  },
+  "files": [
+    "dist/",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json && chmod +x dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "tsx": "^4.19.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/ws": "^8.5.0",
+    "tsx": "^4.19.0",
     "typescript": "^5.7.0"
   }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": ".",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true
+  },
+  "include": ["./*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Configure TypeScript build (tsconfig.build.json) emitting to dist/
- Set up package.json with bin, main, files fields for npm publishing
- Move tsx to devDependencies -- runtime deps are only @modelcontextprotocol/sdk and ws
- Add Dependabot for weekly npm security updates
- Update README with npx standalone usage alongside plugin install

## Verification

All 9 checks pass:
- `npm run build` → clean compile (4 JS + 4 .d.ts in dist/)
- `npm pack` → 17KB tarball
- Install from tarball + `voicemode-channel auth status` → works
- Runtime deps: only @modelcontextprotocol/sdk and ws

## After merge

```bash
npm publish
npx voicemode-channel auth status  # verify from registry
```

## Test plan

- [ ] Merge and run `npm publish`
- [ ] `npx voicemode-channel auth status` from a clean environment
- [ ] `npx voicemode-channel auth login` opens browser and authenticates
- [ ] `npx voicemode-channel` starts MCP server (test with Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>