### PR TITLE
Add Makefile build/test/publish targets + CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# voicemode-channel
+
+Claude Code channel plugin -- inbound voice calls via VoiceMode Connect.
+
+## Build
+
+```bash
+npx tsc --noEmit    # Type check
+npm run build       # Not yet configured -- use tsc directly
+```
+
+## Related Projects
+
+When working on VMC-426 (receiver fixes) or other voicemode-connect tasks:
+
+- **voicemode-connect** repo: Use `npm run typecheck` for type checking, NOT `npx tsc`. The project has a custom TypeScript setup and `npx tsc` pulls in the wrong compiler.
+
+## Auth
+
+- Auth0 domain: dev-2q681p5hobd1dtmm.us.auth0.com
+- Client ID: 1uJR1Q4HMkLkhzOXTg5JFuqBCq0FBsXK (public native app)
+- Credential file: ~/.voicemode/credentials (JSON, shared with Python CLI)
+
+## Git
+
+- Never commit to master -- always create a branch first
+- Standard workflow: branch → commit → push → PR

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,42 @@
-.PHONY: release help
+# voicemode-channel Makefile
+
+.PHONY: help build clean test publish release
 
 help:
 	@echo "Usage: make [target]"
 	@echo ""
 	@echo "Targets:"
-	@echo "  release   Create a new release (bump version, commit, tag, push)"
+	@echo "  build     Compile TypeScript to dist/"
+	@echo "  clean     Remove build artifacts"
+	@echo "  test      Build and test from tarball"
+	@echo "  publish   Build and publish to npm"
+	@echo "  release   Bump version, build, publish, and release plugin"
 	@echo "  help      Show this help"
+
+build:
+	npm run build
+
+clean:
+	rm -rf dist/ *.tgz
+
+test: clean build
+	@echo "Packing and testing..."
+	npm pack
+	@tmpdir=$$(mktemp -d) && \
+		npm install --prefix "$$tmpdir" ./voicemode-channel-*.tgz && \
+		"$$tmpdir/node_modules/.bin/voicemode-channel" auth status && \
+		rm -rf "$$tmpdir" && \
+		echo "" && \
+		echo "Test passed."
+	rm -f voicemode-channel-*.tgz
+
+publish: clean build
+	@echo "Publishing to npm..."
+	@echo ""
+	@echo "Current version: $$(node -p 'require("./package.json").version')"
+	@echo ""
+	npm publish
 
 release:
 	@claude-plugin-release
+	$(MAKE) publish


### PR DESCRIPTION
## Summary

- Makefile: added build, clean, test, publish targets alongside existing release
- `make test` builds, packs, installs from tarball, and verifies auth status works
- `make publish` builds and runs npm publish
- `make release` chains claude-plugin-release + npm publish
- CLAUDE.md: project context for agents (includes voicemode-connect typecheck warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>