### PR TITLE
feat: add status tool to MCP server (VMC-428)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# voicemode-channel
+
+Claude Code channel plugin -- inbound voice calls via VoiceMode Connect.
+
+## Build
+
+```bash
+npx tsc --noEmit    # Type check
+npm run build       # Not yet configured -- use tsc directly
+```
+
+## Related Projects
+
+When working on VMC-426 (receiver fixes) or other voicemode-connect tasks:
+
+- **voicemode-connect** repo: Use `npm run typecheck` for type checking, NOT `npx tsc`. The project has a custom TypeScript setup and `npx tsc` pulls in the wrong compiler.
+
+## Auth
+
+- Auth0 domain: dev-2q681p5hobd1dtmm.us.auth0.com
+- Client ID: 1uJR1Q4HMkLkhzOXTg5JFuqBCq0FBsXK (public native app)
+- Credential file: ~/.voicemode/credentials (JSON, shared with Python CLI)
+
+## Git
+
+- Never commit to master -- always create a branch first
+- Standard workflow: branch → commit → push → PR

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,42 @@
-.PHONY: release help
+# voicemode-channel Makefile
+
+.PHONY: help build clean test publish release
 
 help:
 	@echo "Usage: make [target]"
 	@echo ""
 	@echo "Targets:"
-	@echo "  release   Create a new release (bump version, commit, tag, push)"
+	@echo "  build     Compile TypeScript to dist/"
+	@echo "  clean     Remove build artifacts"
+	@echo "  test      Build and test from tarball"
+	@echo "  publish   Build and publish to npm"
+	@echo "  release   Bump version, build, publish, and release plugin"
 	@echo "  help      Show this help"
+
+build:
+	npm run build
+
+clean:
+	rm -rf dist/ *.tgz
+
+test: clean build
+	@echo "Packing and testing..."
+	npm pack
+	@tmpdir=$$(mktemp -d) && \
+		npm install --prefix "$$tmpdir" ./voicemode-channel-*.tgz && \
+		"$$tmpdir/node_modules/.bin/voicemode-channel" auth status && \
+		rm -rf "$$tmpdir" && \
+		echo "" && \
+		echo "Test passed."
+	rm -f voicemode-channel-*.tgz
+
+publish: clean build
+	@echo "Publishing to npm..."
+	@echo ""
+	@echo "Current version: $$(node -p 'require("./package.json").version')"
+	@echo ""
+	npm publish
 
 release:
 	@claude-plugin-release
+	$(MAKE) publish

--- a/index.ts
+++ b/index.ts
@@ -130,6 +130,8 @@ if (process.env.VOICEMODE_CHANNEL_ENABLED !== 'true') {
   process.exit(0)
 }
 
+const WS_URL = process.env.VOICEMODE_CONNECT_WS_URL ?? 'wss://voicemode.dev/ws'
+
 const CHANNEL_NAME = 'voicemode-channel'
 const CHANNEL_VERSION = '0.1.4'
 
@@ -211,6 +213,16 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
+        name: 'status',
+        description:
+          'Check the current status of the VoiceMode channel. ' +
+          'Returns connection state, gateway URL, session IDs, auth info, and current profile.',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {},
+        },
+      },
+      {
         name: 'profile',
         description:
           'Get or update the agent profile. ' +
@@ -250,6 +262,10 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => {
 mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params
 
+  if (name === 'status') {
+    return handle_status_tool()
+  }
+
   if (name === 'profile') {
     return handle_profile_tool(args as Record<string, unknown> | undefined)
   }
@@ -263,6 +279,61 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
     isError: true,
   }
 })
+
+// ---------------------------------------------------------------------------
+// Tool handler: status
+// ---------------------------------------------------------------------------
+
+function handle_status_tool() {
+  const lines: string[] = []
+
+  // Connection state
+  const state = gateway?.state ?? 'disconnected'
+  lines.push(`Connection: ${state}`)
+  lines.push(`Gateway: ${WS_URL}`)
+
+  // Session IDs
+  const server_session = gateway?.session_id ?? 'none'
+  const agent_session = gateway?.agent_session_id ?? 'none'
+  lines.push(`Session: ${server_session} (server) / ${agent_session} (agent)`)
+
+  lines.push('')
+
+  // Auth info
+  const creds = load_credentials()
+  if (creds) {
+    const expired = is_expired(creds)
+    const expires_date = new Date(creds.expires_at * 1000)
+    const expires_str = expires_date.toISOString().slice(0, 16)
+
+    lines.push(`Auth: authenticated`)
+
+    const name = creds.user_info?.name as string | undefined
+    const email = creds.user_info?.email as string | undefined
+    if (name || email) {
+      const parts = [name, email ? `(${email})` : null].filter(Boolean).join(' ')
+      lines.push(`User: ${parts}`)
+    }
+
+    lines.push(`Token: ${expired ? 'expired' : 'valid'} (expires ${expires_str})`)
+  } else {
+    lines.push('Auth: not authenticated')
+  }
+
+  lines.push('')
+
+  // Profile
+  lines.push(`Profile: set`)
+  lines.push(`  Name: ${currentProfile.name}`)
+  lines.push(`  Display: ${currentProfile.display_name}`)
+  lines.push(`  Context: ${currentProfile.context ?? 'none'}`)
+  lines.push(`  Voice: ${currentProfile.voice ?? 'default'}`)
+  lines.push(`  Presence: ${currentProfile.presence}`)
+
+  return {
+    content: [{ type: 'text', text: lines.join('\n') }],
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Tool handler: reply


### PR DESCRIPTION
## Summary

- Adds `status` tool to voicemode-channel MCP server (alongside existing `profile` and `reply`)
- Returns connection state, gateway URL, session IDs, auth info, and current profile
- Read-only, no parameters -- agents can check if they're connected before voice operations

## Example output

```
Connection: connected
Gateway: wss://voicemode.dev/ws
Session: abc123 (server) / def456 (agent)

Auth: authenticated
User: Mike (mike@example.com)
Token: valid (expires 2026-04-03T23:53)

Profile: set
  Name: cora
  Display: Cora 7
  Context: voicemode-channel
```

## Test plan

- [ ] `status` returns correct state in MCP Inspector
- [ ] Shows "disconnected" when gateway not connected
- [ ] Shows auth info from credentials
- [ ] Shows profile after calling `profile` tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>