### PR TITLE
feat(maildir): Maildir hooks and MCP tools (VMC-452)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -27,6 +27,8 @@ import { GatewayClient, get_project_context } from './gateway.js'
 import type { ProfileData } from './gateway.js'
 import { login } from './auth.js'
 import { load_credentials, is_expired, CREDENTIALS_FILE, get_valid_token } from './credentials.js'
+import { list_messages, read_message } from './maildir.js'
+import type { MaildirMessage } from './maildir.js'
 
 // ---------------------------------------------------------------------------
 // Load ~/.voicemode/voicemode.env (simple dotenv parsing)
@@ -265,6 +267,47 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => {
           },
         },
       },
+      {
+        name: 'list_messages',
+        description:
+          'List voice messages from the Maildir conversation history. ' +
+          'By default, only shows messages from the current agent session. ' +
+          'Use all_sessions to see messages from all sessions.',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            all_sessions: {
+              type: 'boolean',
+              description: 'If true, show messages from all sessions (default: false, current session only)',
+            },
+            direction: {
+              type: 'string',
+              description: 'Filter by message direction',
+              enum: ['inbound', 'outbound'],
+            },
+            limit: {
+              type: 'number',
+              description: 'Maximum number of messages to return (default: 50)',
+            },
+          },
+        },
+      },
+      {
+        name: 'read_message',
+        description:
+          'Read the full content of a voice message by filename. ' +
+          'Use list_messages first to find message filenames.',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            filename: {
+              type: 'string',
+              description: 'The message filename (e.g. "vm-abc123def456")',
+            },
+          },
+          required: ['filename'],
+        },
+      },
     ],
   }
 })
@@ -282,6 +325,14 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
 
   if (name === 'reply') {
     return handle_reply_tool(args as Record<string, unknown> | undefined)
+  }
+
+  if (name === 'list_messages') {
+    return handle_list_messages_tool(args as Record<string, unknown> | undefined)
+  }
+
+  if (name === 'read_message') {
+    return handle_read_message_tool(args as Record<string, unknown> | undefined)
   }
 
   return {
@@ -436,6 +487,74 @@ function handle_profile_tool(args: Record<string, unknown> | undefined) {
       type: 'text',
       text: JSON.stringify(currentProfile, null, 2),
     }],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tool handler: list_messages
+// ---------------------------------------------------------------------------
+
+function handle_list_messages_tool(args: Record<string, unknown> | undefined) {
+  const all_sessions = args?.all_sessions === true
+  const direction = args?.direction as 'inbound' | 'outbound' | undefined
+  const limit = typeof args?.limit === 'number' ? Math.max(1, Math.min(args.limit, 500)) : 50
+
+  // Default to current session unless all_sessions is true
+  const agent_session_id = all_sessions ? undefined : (gateway?.agent_session_id ?? undefined)
+
+  // Validate direction if provided
+  if (direction !== undefined && direction !== 'inbound' && direction !== 'outbound') {
+    return {
+      content: [{ type: 'text', text: 'Error: direction must be "inbound" or "outbound"' }],
+      isError: true,
+    }
+  }
+
+  const messages = list_messages({ agent_session_id, direction, limit })
+
+  if (messages.length === 0) {
+    const scope = all_sessions ? 'any session' : 'the current session'
+    return {
+      content: [{ type: 'text', text: `No messages found for ${scope}.` }],
+    }
+  }
+
+  // Format as a summary list (filename, direction, date, subject preview)
+  const lines = messages.map((msg: MaildirMessage) => {
+    const dir_arrow = msg.direction === 'inbound' ? '<-' : '->'
+    const preview = msg.subject.length > 60 ? msg.subject.slice(0, 60) + '...' : msg.subject
+    return `${msg.filename}  ${dir_arrow}  ${msg.date}  ${preview}`
+  })
+
+  const header = `Messages (${messages.length}${messages.length >= limit ? '+' : ''}):`
+  return {
+    content: [{ type: 'text', text: [header, ...lines].join('\n') }],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tool handler: read_message
+// ---------------------------------------------------------------------------
+
+function handle_read_message_tool(args: Record<string, unknown> | undefined) {
+  const filename = args?.filename
+  if (typeof filename !== 'string' || filename.trim().length === 0) {
+    return {
+      content: [{ type: 'text', text: 'Error: filename parameter is required and must be non-empty' }],
+      isError: true,
+    }
+  }
+
+  const message = read_message(filename.trim())
+  if (!message) {
+    return {
+      content: [{ type: 'text', text: `Message not found: ${filename}` }],
+      isError: true,
+    }
+  }
+
+  return {
+    content: [{ type: 'text', text: JSON.stringify(message, null, 2) }],
   }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -27,6 +27,7 @@ import { GatewayClient, get_project_context } from './gateway.js'
 import type { ProfileData } from './gateway.js'
 import { login } from './auth.js'
 import { load_credentials, is_expired, CREDENTIALS_FILE, get_valid_token } from './credentials.js'
+import { write_message } from './maildir.js'
 
 // ---------------------------------------------------------------------------
 // Load ~/.voicemode/voicemode.env (simple dotenv parsing)
@@ -166,6 +167,10 @@ let currentProfile: ProfileData = {
   voice: null,
   presence: 'available',
 }
+
+// Track the last inbound caller name so outbound replies can reference it.
+// Falls back to 'user' if no inbound message has been received yet.
+let last_caller_name = 'user'
 
 // ---------------------------------------------------------------------------
 // MCP server with channel capability
@@ -391,6 +396,22 @@ function handle_reply_tool(args: Record<string, unknown> | undefined) {
 
   log(`Sent reply via gateway: id=${msg_id} text="${truncate(text.trim(), 80)}"`)
 
+  // Persist outbound message to Maildir (best-effort -- never break reply flow)
+  try {
+    write_message({
+      direction: 'outbound',
+      from_name: currentProfile.name,
+      to_name: last_caller_name,
+      text: text.trim(),
+      session_id: gateway.session_id ?? 'unknown',
+      agent_session_id: gateway.agent_session_id ?? 'unknown',
+      agent_name: currentProfile.name,
+    })
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err)
+    log(`Maildir write failed (non-fatal): ${message}`, 'WARN')
+  }
+
   return {
     content: [{
       type: 'text',
@@ -550,6 +571,9 @@ function start_gateway(): void {
     const device_id = typeof user_id === 'string' && user_id.length > 0
       ? user_id
       : undefined
+
+    // Remember caller name for outbound reply attribution
+    last_caller_name = caller
 
     log(`Received voice event: from="${caller}" text="${truncate(safe_text.trim(), 80)}"`)
 

--- a/index.ts
+++ b/index.ts
@@ -24,6 +24,7 @@ import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { randomBytes } from 'node:crypto'
 import { GatewayClient, get_project_context } from './gateway.js'
+import { write_message } from './maildir.js'
 import type { ProfileData } from './gateway.js'
 import { login } from './auth.js'
 import { load_credentials, is_expired, CREDENTIALS_FILE, get_valid_token } from './credentials.js'
@@ -557,6 +558,25 @@ function start_gateway(): void {
       const message = err instanceof Error ? err.message : String(err)
       log(`Error pushing voice event to channel: ${message}`)
     })
+
+    // Persist inbound message to Maildir (best-effort -- never break voice pipeline)
+    try {
+      const filename = write_message({
+        direction: 'inbound',
+        from_name: caller,
+        to_name: currentProfile.name,
+        text: safe_text.trim(),
+        session_id: gateway?.session_id ?? 'unknown',
+        agent_session_id: gateway?.agent_session_id ?? 'unknown',
+        agent_name: currentProfile.name,
+      })
+      if (filename) {
+        log(`Maildir: wrote inbound message ${filename}`, 'DEBUG')
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err)
+      log(`Maildir write failed (non-fatal): ${message}`, 'WARN')
+    }
   })
 
   // Start the connection (non-blocking -- reconnects in the background)

--- a/maildir.ts
+++ b/maildir.ts
@@ -12,8 +12,8 @@
  *   VOICEMODE_MAILDIR_ENABLED Set to 'false' to disable persistence
  */
 
-import { mkdirSync, writeFileSync, renameSync, existsSync } from 'node:fs'
-import { join } from 'node:path'
+import { mkdirSync, writeFileSync, renameSync, existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
 import { createHash } from 'node:crypto'
 import { homedir } from 'node:os'
 
@@ -26,6 +26,19 @@ export interface VoiceMessage {
   agent_session_id: string  // claude session
   agent_name: string
   timestamp?: Date
+}
+
+export interface MaildirMessage {
+  filename: string
+  from: string
+  to: string
+  date: string
+  subject: string
+  direction: string
+  session_id: string
+  agent_session_id: string
+  agent_name: string
+  body: string
 }
 
 const DEFAULT_MAILDIR = join(homedir(), '.voicemode', 'maildir', 'channel')
@@ -93,4 +106,159 @@ export function write_message(msg: VoiceMessage): string | null {
   renameSync(tmp_path, new_path)
 
   return filename
+}
+
+// ---------------------------------------------------------------------------
+// Read helpers -- parse RFC 2822 messages from Maildir
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse an RFC 2822 message string into headers and body.
+ * Headers are separated from the body by the first blank line.
+ */
+function parse_message(raw: string): { headers: Record<string, string>; body: string } {
+  const headers: Record<string, string> = {}
+  const separator = raw.indexOf('\n\n')
+  const header_block = separator >= 0 ? raw.slice(0, separator) : raw
+  const body = separator >= 0 ? raw.slice(separator + 2).trimEnd() : ''
+
+  for (const line of header_block.split('\n')) {
+    const colon = line.indexOf(':')
+    if (colon < 1) continue
+    const key = line.slice(0, colon).trim()
+    const value = line.slice(colon + 1).trim()
+    headers[key] = value
+  }
+
+  return { headers, body }
+}
+
+/**
+ * Convert parsed headers + body into a MaildirMessage.
+ */
+function to_maildir_message(filename: string, headers: Record<string, string>, body: string): MaildirMessage {
+  return {
+    filename,
+    from: headers['From'] ?? '',
+    to: headers['To'] ?? '',
+    date: headers['Date'] ?? '',
+    subject: headers['Subject'] ?? '',
+    direction: headers['X-VoiceMode-Direction'] ?? '',
+    session_id: headers['X-VoiceMode-Session'] ?? '',
+    agent_session_id: headers['X-VoiceMode-Agent-Session'] ?? '',
+    agent_name: headers['X-VoiceMode-Agent'] ?? '',
+    body,
+  }
+}
+
+/**
+ * Read a single message by filename from the Maildir.
+ *
+ * Security: rejects filenames containing '..' or '/' and verifies the
+ * resolved path is within the Maildir directory. Only returns messages
+ * with X-Transport: voicemode-connect header.
+ *
+ * Returns null if the file doesn't exist, fails security checks, or
+ * has the wrong X-Transport header.
+ */
+export function read_message(filename: string): MaildirMessage | null {
+  // Path traversal prevention: reject suspicious filenames
+  if (filename.includes('..') || filename.includes('/')) return null
+
+  const maildir = get_maildir_path()
+  const maildir_resolved = resolve(maildir)
+
+  // Check new/ and cur/ directories
+  for (const sub of ['new', 'cur']) {
+    const file_path = join(maildir, sub, filename)
+    const resolved_path = resolve(file_path)
+
+    // Verify resolved path is within the Maildir directory
+    if (!resolved_path.startsWith(maildir_resolved + '/')) continue
+
+    if (!existsSync(resolved_path)) continue
+
+    try {
+      const raw = readFileSync(resolved_path, 'utf8')
+      const { headers, body } = parse_message(raw)
+
+      // Only return messages with the correct transport header
+      if (headers['X-Transport'] !== 'voicemode-connect') return null
+
+      return to_maildir_message(filename, headers, body)
+    } catch {
+      return null
+    }
+  }
+
+  return null
+}
+
+/**
+ * List messages from the Maildir, filtered by session and direction.
+ *
+ * Scans both new/ and cur/ directories. Only includes messages with
+ * X-Transport: voicemode-connect header.
+ *
+ * Returns messages sorted by date descending (newest first).
+ */
+export function list_messages(options: {
+  agent_session_id?: string
+  direction?: 'inbound' | 'outbound'
+  limit?: number
+}): MaildirMessage[] {
+  const { agent_session_id, direction, limit = 50 } = options
+  const maildir = get_maildir_path()
+  const messages: MaildirMessage[] = []
+
+  for (const sub of ['new', 'cur']) {
+    const dir_path = join(maildir, sub)
+    if (!existsSync(dir_path)) continue
+
+    let filenames: string[]
+    try {
+      filenames = readdirSync(dir_path)
+    } catch {
+      continue
+    }
+
+    for (const filename of filenames) {
+      // Skip hidden files and non-vm files
+      if (filename.startsWith('.')) continue
+
+      const file_path = join(dir_path, filename)
+      let raw: string
+      try {
+        raw = readFileSync(file_path, 'utf8')
+      } catch {
+        continue
+      }
+
+      const { headers, body } = parse_message(raw)
+
+      // Only include voicemode-connect messages
+      if (headers['X-Transport'] !== 'voicemode-connect') continue
+
+      // Filter by agent_session_id if provided
+      if (agent_session_id && headers['X-VoiceMode-Agent-Session'] !== agent_session_id) continue
+
+      // Filter by direction if provided
+      if (direction && headers['X-VoiceMode-Direction'] !== direction) continue
+
+      messages.push(to_maildir_message(filename, headers, body))
+    }
+  }
+
+  // Sort by date descending (newest first)
+  messages.sort((a, b) => {
+    const date_a = new Date(a.date).getTime()
+    const date_b = new Date(b.date).getTime()
+    // Handle invalid dates by pushing them to the end
+    if (isNaN(date_a) && isNaN(date_b)) return 0
+    if (isNaN(date_a)) return 1
+    if (isNaN(date_b)) return -1
+    return date_b - date_a
+  })
+
+  return messages.slice(0, limit)
 }

--- a/maildir.ts
+++ b/maildir.ts
@@ -1,0 +1,96 @@
+/**
+ * Maildir persistence for VoiceMode voice messages.
+ *
+ * Writes inbound (user speaks) and outbound (agent replies) messages to Maildir
+ * format so they can be indexed by notmuch and accessed via MCP tools.
+ *
+ * Maildir protocol: write to tmp/ first, then rename() to new/ (atomic, no locking).
+ * Dedup: content-hash filename (sha256(from|timestamp|text)[:16]) prevents duplicates.
+ *
+ * Environment variables:
+ *   VOICEMODE_MAILDIR_PATH    Override default ~/.voicemode/maildir/channel
+ *   VOICEMODE_MAILDIR_ENABLED Set to 'false' to disable persistence
+ */
+
+import { mkdirSync, writeFileSync, renameSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { createHash } from 'node:crypto'
+import { homedir } from 'node:os'
+
+export interface VoiceMessage {
+  direction: 'inbound' | 'outbound'
+  from_name: string
+  to_name: string
+  text: string
+  session_id: string        // gateway session
+  agent_session_id: string  // claude session
+  agent_name: string
+  timestamp?: Date
+}
+
+const DEFAULT_MAILDIR = join(homedir(), '.voicemode', 'maildir', 'channel')
+
+export function get_maildir_path(): string {
+  return process.env.VOICEMODE_MAILDIR_PATH || DEFAULT_MAILDIR
+}
+
+/**
+ * Write a voice message to Maildir.
+ *
+ * Returns the filename if written (or already exists), null if persistence is disabled.
+ * Uses atomic tmp/ -> new/ rename to guarantee no partial reads.
+ * Silently skips duplicate messages (same from/timestamp/text hash).
+ */
+export function write_message(msg: VoiceMessage): string | null {
+  if (process.env.VOICEMODE_MAILDIR_ENABLED === 'false') return null
+
+  const maildir = get_maildir_path()
+  const ts = msg.timestamp ?? new Date()
+
+  // Ensure Maildir structure exists
+  for (const sub of ['tmp', 'new', 'cur']) {
+    mkdirSync(join(maildir, sub), { recursive: true })
+  }
+
+  // Content-hash dedup: sha256(from|timestamp|text)[:16]
+  const hash = createHash('sha256')
+    .update(`${msg.from_name}|${ts.toISOString()}|${msg.text}`)
+    .digest('hex')
+    .slice(0, 16)
+  const filename = `vm-${hash}`
+
+  // Skip if already written (dedup -- check both new/ and cur/)
+  const new_path = join(maildir, 'new', filename)
+  const cur_path = join(maildir, 'cur', filename)
+  if (existsSync(new_path) || existsSync(cur_path)) return filename
+
+  // Slugify name -> email-safe local part
+  const slug = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '')
+
+  // RFC 2822 message
+  const subject = msg.text.length > 60 ? msg.text.slice(0, 60) + '...' : msg.text
+  const rfc_date = ts.toUTCString()  // e.g. "Sat, 05 Apr 2026 12:00:00 GMT"
+
+  const email = [
+    `From: ${msg.from_name} <${slug(msg.from_name)}@voicemode-connect>`,
+    `To: ${msg.to_name} <${slug(msg.to_name)}@voicemode-connect>`,
+    `Date: ${rfc_date}`,
+    `Subject: ${subject}`,
+    `Message-ID: <vm-${hash}@voicemode-connect>`,
+    `X-Transport: voicemode-connect`,
+    `X-VoiceMode-Direction: ${msg.direction}`,
+    `X-VoiceMode-Session: ${msg.session_id}`,
+    `X-VoiceMode-Agent-Session: ${msg.agent_session_id}`,
+    `X-VoiceMode-Agent: ${msg.agent_name}`,
+    '',
+    msg.text,
+    '',
+  ].join('\n')
+
+  // Atomic write: tmp/ -> new/
+  const tmp_path = join(maildir, 'tmp', filename)
+  writeFileSync(tmp_path, email)
+  renameSync(tmp_path, new_path)
+
+  return filename
+}


### PR DESCRIPTION
## Summary

Completes VMC-452 impl-002 through impl-004: voice messages are now persisted to Maildir and queryable via MCP tools.

- **impl-002**: Inbound voice messages (user speaks) written to Maildir after gateway delivery
- **impl-003**: Outbound replies (agent speaks) written to Maildir after gateway send
- **impl-004**: `list_messages` and `read_message` MCP tools for agents to query conversation history

### Details

- Atomic Maildir writes (tmp/ → new/) with content-hash dedup
- Session-scoped message listing (default) with `all_sessions` option
- Path traversal prevention on read_message (reject `..`/`/`, resolve+startsWith check)
- X-Transport header verification on all reads
- Best-effort persistence -- Maildir failures never break the voice pipeline
- `last_caller_name` tracking for outbound reply attribution

## Test plan

- [ ] `make build` passes (verified)
- [ ] Send voice message via Connect → verify file appears in `~/.voicemode/maildir/channel/new/`
- [ ] Reply via channel → verify outbound file appears
- [ ] Use `list_messages` tool in MCP shell → verify session filtering works
- [ ] Use `read_message` tool → verify full message content returned
- [ ] Verify `notmuch new` indexes the Maildir correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)