### PR TITLE
feat(maildir): message-state flags, bulk reads, R-on-reply (VMC-490)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -24,7 +24,7 @@ import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { randomBytes } from 'node:crypto'
 import { GatewayClient, get_project_context } from './gateway.js'
-import { write_message, list_messages, read_message } from './maildir.js'
+import { write_message, list_messages, read_message, mark_read } from './maildir.js'
 import type { MaildirMessage } from './maildir.js'
 import type { ProfileData } from './gateway.js'
 import { login } from './auth.js'
@@ -300,7 +300,9 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => {
         name: 'read_message',
         description:
           'Read the full content of a voice message by filename. ' +
-          'Use list_messages first to find message filenames.',
+          'Use list_messages first to find message filenames. ' +
+          'By default, marks the message as Seen (moves from new/ to cur/ with S flag). ' +
+          'Pass mark_read: false to leave the message unread.',
         inputSchema: {
           type: 'object' as const,
           properties: {
@@ -308,8 +310,37 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => {
               type: 'string',
               description: 'The message filename (e.g. "vm-abc123def456")',
             },
+            mark_read: {
+              type: 'boolean',
+              description: 'Whether to mark the message as Seen on read (default: true)',
+            },
           },
           required: ['filename'],
+        },
+      },
+      {
+        name: 'mark_read',
+        description:
+          'Apply Maildir flags to one or more messages (bulk supported). ' +
+          'Default flag is "S" (Seen). Files are moved from new/ to cur/ with a ' +
+          ':2,FLAGS suffix per the Maildir spec. Flags are merged with any existing ' +
+          'flags on the file (e.g. marking an "R" message as Seen yields ":2,RS"). ' +
+          'Use this when you want to mark multiple messages read in one call, or to ' +
+          'apply non-Seen flags (R=Replied, F=Flagged, T=Trashed, D=Draft).',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            filenames: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Message filenames to mark (from list_messages)',
+            },
+            flags: {
+              type: 'string',
+              description: 'Flag letters to apply, e.g. "S", "RS" (default: "S")',
+            },
+          },
+          required: ['filenames'],
         },
       },
     ],
@@ -337,6 +368,10 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
 
   if (name === 'read_message') {
     return handle_read_message_tool(args as Record<string, unknown> | undefined)
+  }
+
+  if (name === 'mark_read') {
+    return handle_mark_read_tool(args as Record<string, unknown> | undefined)
   }
 
   return {
@@ -565,7 +600,10 @@ function handle_read_message_tool(args: Record<string, unknown> | undefined) {
     }
   }
 
-  const message = read_message(filename.trim())
+  // mark_read defaults to true -- callers pass false to opt out
+  const should_mark = typeof args?.mark_read === 'boolean' ? args.mark_read : true
+
+  const message = read_message(filename.trim(), { mark_read: should_mark })
   if (!message) {
     return {
       content: [{ type: 'text', text: `Message not found: ${filename}` }],
@@ -575,6 +613,57 @@ function handle_read_message_tool(args: Record<string, unknown> | undefined) {
 
   return {
     content: [{ type: 'text', text: JSON.stringify(message, null, 2) }],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tool handler: mark_read
+// ---------------------------------------------------------------------------
+
+function handle_mark_read_tool(args: Record<string, unknown> | undefined) {
+  const filenames_arg = args?.filenames
+  if (!Array.isArray(filenames_arg) || filenames_arg.length === 0) {
+    return {
+      content: [{ type: 'text', text: 'Error: filenames parameter is required and must be a non-empty array' }],
+      isError: true,
+    }
+  }
+
+  // Validate each filename is a non-empty string
+  const filenames: string[] = []
+  for (const item of filenames_arg) {
+    if (typeof item !== 'string' || item.trim().length === 0) {
+      return {
+        content: [{ type: 'text', text: 'Error: every filename must be a non-empty string' }],
+        isError: true,
+      }
+    }
+    filenames.push(item.trim())
+  }
+
+  const flags = typeof args?.flags === 'string' && args.flags.length > 0 ? args.flags : 'S'
+
+  const results = mark_read(filenames, flags)
+
+  // Format a human-readable summary alongside the structured result
+  const found_count = results.filter(r => r.found).length
+  const missing_count = results.length - found_count
+
+  const lines: string[] = []
+  lines.push(`mark_read: ${found_count}/${results.length} marked with flags=${flags}`)
+  if (missing_count > 0) {
+    lines.push(`  ${missing_count} not found`)
+  }
+  for (const r of results) {
+    if (r.found) {
+      lines.push(`  [OK]  ${r.filename} -> ${r.new_filename}`)
+    } else {
+      lines.push(`  [??]  ${r.filename} (not found)`)
+    }
+  }
+
+  return {
+    content: [{ type: 'text', text: lines.join('\n') }],
   }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -24,7 +24,7 @@ import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { randomBytes } from 'node:crypto'
 import { GatewayClient, get_project_context } from './gateway.js'
-import { write_message, list_messages, read_message, mark_read } from './maildir.js'
+import { write_message, list_messages, read_message, mark_read, count_unread } from './maildir.js'
 import type { MaildirMessage } from './maildir.js'
 import type { ProfileData } from './gateway.js'
 import { login } from './auth.js'
@@ -208,7 +208,8 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => {
         description:
           'Send a voice reply to the user through VoiceMode. ' +
           'Use this to respond to inbound voice channel events. ' +
-          'The reply is spoken aloud on the user\'s device via TTS.',
+          'The reply is spoken aloud on the user\'s device via TTS. ' +
+          'Pass in_reply_to to mark the source message with the R (Replied) flag.',
         inputSchema: {
           type: 'object' as const,
           properties: {
@@ -223,6 +224,10 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => {
             wait_for_response: {
               type: 'boolean',
               description: 'Whether to listen for user response after speaking (default: false)',
+            },
+            in_reply_to: {
+              type: 'string',
+              description: 'Filename of the inbound message being replied to; receives R flag on successful send',
             },
           },
           required: ['text'],
@@ -436,6 +441,17 @@ function handle_status_tool() {
 
   lines.push('')
 
+  // Unread message count (supports notification-append pattern)
+  try {
+    const unread = count_unread()
+    lines.push(`Unread: ${unread}`)
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err)
+    lines.push(`Unread: unavailable (${message})`)
+  }
+
+  lines.push('')
+
   // Profile
   lines.push(`Profile: set`)
   lines.push(`  Name: ${currentProfile.name}`)
@@ -465,6 +481,9 @@ function handle_reply_tool(args: Record<string, unknown> | undefined) {
 
   const voice = typeof args?.voice === 'string' ? args.voice : (currentProfile.voice || undefined)
   const wait_for_response = typeof args?.wait_for_response === 'boolean' ? args.wait_for_response : undefined
+  const in_reply_to = typeof args?.in_reply_to === 'string' && args.in_reply_to.trim().length > 0
+    ? args.in_reply_to.trim()
+    : undefined
 
   // Check gateway connection
   if (!gateway || gateway.state !== 'connected') {
@@ -494,6 +513,23 @@ function handle_reply_tool(args: Record<string, unknown> | undefined) {
   }
 
   log(`Sent reply via gateway: id=${msg_id} text="${truncate(text.trim(), 80)}"`)
+
+  // Apply R (Replied) flag to the source message when reply-context is provided.
+  // Best-effort -- never break reply flow if the source file is gone.
+  if (in_reply_to) {
+    try {
+      const results = mark_read([in_reply_to], 'R')
+      const r = results[0]
+      if (r?.found) {
+        log(`Marked ${in_reply_to} with R flag -> ${r.new_filename}`, 'DEBUG')
+      } else {
+        log(`R flag: source message not found: ${in_reply_to}`, 'WARN')
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err)
+      log(`R flag application failed (non-fatal): ${message}`, 'WARN')
+    }
+  }
 
   // Persist outbound message to Maildir (best-effort -- never break reply flow)
   try {

--- a/index.ts
+++ b/index.ts
@@ -276,7 +276,9 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => {
         description:
           'List voice messages from the Maildir conversation history. ' +
           'By default, only shows messages from the current agent session. ' +
-          'Use all_sessions to see messages from all sessions.',
+          'Use all_sessions to see messages from all sessions. ' +
+          'Pass include_body: true to fetch bodies in bulk (truncated by body_max_length). ' +
+          'Pass unread: true to see only unread messages (no S flag).',
         inputSchema: {
           type: 'object' as const,
           properties: {
@@ -292,6 +294,18 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => {
             limit: {
               type: 'number',
               description: 'Maximum number of messages to return (default: 50)',
+            },
+            include_body: {
+              type: 'boolean',
+              description: 'If true, include message bodies in the response (default: false)',
+            },
+            body_max_length: {
+              type: 'number',
+              description: 'Max body length when include_body is true; 0 = unlimited (default: 2000)',
+            },
+            unread: {
+              type: 'boolean',
+              description: 'If true, only return unread messages; if false, only read; omit for both',
             },
           },
         },
@@ -553,6 +567,9 @@ function handle_list_messages_tool(args: Record<string, unknown> | undefined) {
   const all_sessions = args?.all_sessions === true
   const direction = args?.direction as 'inbound' | 'outbound' | undefined
   const limit = typeof args?.limit === 'number' ? Math.max(1, Math.min(args.limit, 500)) : 50
+  const include_body = args?.include_body === true
+  const body_max_length = typeof args?.body_max_length === 'number' ? Math.max(0, args.body_max_length) : 2000
+  const unread = typeof args?.unread === 'boolean' ? args.unread : undefined
 
   // Default to current session unless all_sessions is true
   const agent_session_id = all_sessions ? undefined : (gateway?.agent_session_id ?? undefined)
@@ -565,12 +582,20 @@ function handle_list_messages_tool(args: Record<string, unknown> | undefined) {
     }
   }
 
-  const messages = list_messages({ agent_session_id, direction, limit })
+  const messages = list_messages({ agent_session_id, direction, limit, include_body, body_max_length, unread })
 
   if (messages.length === 0) {
     const scope = all_sessions ? 'any session' : 'the current session'
+    const state = unread === true ? 'unread ' : unread === false ? 'read ' : ''
     return {
-      content: [{ type: 'text', text: `No messages found for ${scope}.` }],
+      content: [{ type: 'text', text: `No ${state}messages found for ${scope}.` }],
+    }
+  }
+
+  // When bodies are requested, return structured JSON so the caller can work with them.
+  if (include_body) {
+    return {
+      content: [{ type: 'text', text: JSON.stringify(messages, null, 2) }],
     }
   }
 

--- a/maildir.test.ts
+++ b/maildir.test.ts
@@ -79,8 +79,8 @@ describe('maildir', () => {
       const files = readdirSync(new_dir)
       assert.ok(files.includes(filename), `File ${filename} should exist in new/`)
 
-      // Read back and verify headers
-      const result = read_message(filename)
+      // Read back and verify headers (opt out of auto-mark so file stays in new/)
+      const result = read_message(filename, { mark_read: false })
       assert.ok(result, 'read_message should return the written message')
 
       assert.ok(result.from.includes('Alice'), 'From header should contain sender name')
@@ -199,7 +199,7 @@ describe('maildir', () => {
   // 4. read_message
   // -----------------------------------------------------------------------
   describe('read_message', () => {
-    it('reads back a written message with all fields matching', () => {
+    it('reads back a written message with all fields matching (mark_read: false)', () => {
       const msg = make_message({
         text: 'Read me back please',
         from_name: 'Sender',
@@ -214,7 +214,7 @@ describe('maildir', () => {
       const filename = write_message(msg)
       assert.ok(filename)
 
-      const result = read_message(filename)
+      const result = read_message(filename, { mark_read: false })
       assert.ok(result, 'read_message should return a message')
 
       assert.equal(result.filename, filename)
@@ -226,11 +226,67 @@ describe('maildir', () => {
       assert.equal(result.agent_name, 'ReadAgent')
       assert.equal(result.body, 'Read me back please')
       assert.equal(result.subject, 'Read me back please')
+
+      // mark_read: false should leave the file in new/ untouched
+      assert.ok(readdirSync(join(tmp_dir, 'new')).includes(filename))
+      const cur_exists = readdirSync(tmp_dir).includes('cur')
+        ? readdirSync(join(tmp_dir, 'cur')).length
+        : 0
+      assert.equal(cur_exists, 0, 'cur/ should be empty when mark_read: false')
     })
 
     it('returns null for non-existent messages', () => {
       const result = read_message('vm-doesnotexist')
       assert.equal(result, null)
+    })
+
+    it('marks the message as read by default (moves new/ -> cur/ with S flag)', () => {
+      const filename = write_message(make_message({ text: 'auto-mark' }))!
+      assert.ok(filename)
+
+      const result = read_message(filename)
+      assert.ok(result, 'read_message should return a message')
+
+      // Filename in the returned message reflects the new on-disk name
+      assert.equal(result.filename, `${filename}:2,S`)
+      assert.equal(result.body, 'auto-mark')
+
+      // File should have moved to cur/ with S flag
+      assert.equal(readdirSync(join(tmp_dir, 'new')).length, 0)
+      const cur_files = readdirSync(join(tmp_dir, 'cur'))
+      assert.equal(cur_files.length, 1)
+      assert.equal(cur_files[0], `${filename}:2,S`)
+    })
+
+    it('can read a message by base name after it has been marked', () => {
+      const filename = write_message(make_message({ text: 'base-lookup' }))!
+
+      // First read auto-marks -- file is now at cur/<filename>:2,S
+      const first = read_message(filename)
+      assert.ok(first)
+      assert.equal(first.filename, `${filename}:2,S`)
+
+      // Second read via the original bare filename still finds the file (base-name lookup)
+      const second = read_message(filename, { mark_read: false })
+      assert.ok(second, 'base-name lookup should locate the flagged file')
+      assert.equal(second.body, 'base-lookup')
+      assert.equal(second.filename, `${filename}:2,S`)
+    })
+
+    it('mark_read: false on a subsequent read preserves existing flags', () => {
+      const filename = write_message(make_message({ text: 'preserve-flags' }))!
+
+      // Auto-mark first call (S flag applied)
+      read_message(filename)
+
+      // Read again with mark_read: false -- should find the :2,S file and not modify it
+      const cur_before = readdirSync(join(tmp_dir, 'cur'))
+      const result = read_message(filename, { mark_read: false })
+      const cur_after = readdirSync(join(tmp_dir, 'cur'))
+
+      assert.ok(result)
+      assert.deepEqual(cur_before, cur_after, 'cur/ contents unchanged when mark_read: false')
+      assert.equal(result.filename, `${filename}:2,S`)
     })
   })
 
@@ -506,6 +562,27 @@ describe('maildir', () => {
       const results = mark_read([filename], 'rs')
 
       assert.equal(results[0].new_filename, `${filename}:2,RS`)
+    })
+
+    it('applies custom flags to a bulk batch in a single call', () => {
+      const f1 = write_message(make_message({ text: 'bulk-custom-1', timestamp: new Date('2026-04-05T10:00:00Z') }))!
+      const f2 = write_message(make_message({ text: 'bulk-custom-2', timestamp: new Date('2026-04-05T11:00:00Z') }))!
+      const f3 = write_message(make_message({ text: 'bulk-custom-3', timestamp: new Date('2026-04-05T12:00:00Z') }))!
+
+      // Apply custom flag set (R + S) across the batch -- matches the mark_read MCP tool API
+      const results = mark_read([f1, f2, f3], 'RS')
+
+      assert.equal(results.length, 3)
+      assert.ok(results.every(r => r.found), 'all three should be found')
+      assert.equal(results[0].new_filename, `${f1}:2,RS`)
+      assert.equal(results[1].new_filename, `${f2}:2,RS`)
+      assert.equal(results[2].new_filename, `${f3}:2,RS`)
+
+      // All files moved to cur/ with the RS flag set
+      assert.equal(readdirSync(join(tmp_dir, 'new')).length, 0)
+      const cur_files = readdirSync(join(tmp_dir, 'cur')).sort()
+      assert.equal(cur_files.length, 3)
+      assert.ok(cur_files.every(name => name.endsWith(':2,RS')))
     })
   })
 })

--- a/maildir.test.ts
+++ b/maildir.test.ts
@@ -10,7 +10,16 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, readdirSyn
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
-import { write_message, read_message, list_messages, get_maildir_path } from './maildir.js'
+import {
+  write_message,
+  read_message,
+  list_messages,
+  get_maildir_path,
+  mark_read,
+  parse_maildir_filename,
+  merge_flags,
+  build_maildir_filename,
+} from './maildir.js'
 import type { VoiceMessage } from './maildir.js'
 
 // ---------------------------------------------------------------------------
@@ -298,6 +307,205 @@ describe('maildir', () => {
         // Directory doesn't exist -- that's expected
       }
       assert.equal(file_count, 0, 'No files should be written when persistence is disabled')
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // 8. Maildir filename parsing helpers (pure functions)
+  // -----------------------------------------------------------------------
+  describe('parse_maildir_filename', () => {
+    it('returns empty flags for a bare basename', () => {
+      assert.deepEqual(parse_maildir_filename('vm-abc123'), { base: 'vm-abc123', flags: '' })
+    })
+
+    it('splits base and flags on :2, marker', () => {
+      assert.deepEqual(parse_maildir_filename('vm-abc123:2,S'), { base: 'vm-abc123', flags: 'S' })
+      assert.deepEqual(parse_maildir_filename('vm-abc123:2,RS'), { base: 'vm-abc123', flags: 'RS' })
+    })
+
+    it('preserves empty flags after :2, marker', () => {
+      assert.deepEqual(parse_maildir_filename('vm-abc123:2,'), { base: 'vm-abc123', flags: '' })
+    })
+
+    it('treats unknown info markers (:1,) as no flags', () => {
+      assert.deepEqual(parse_maildir_filename('vm-abc123:1,foo'), { base: 'vm-abc123:1,foo', flags: '' })
+    })
+  })
+
+  describe('merge_flags', () => {
+    it('returns sorted unique flags', () => {
+      assert.equal(merge_flags('S', 'R'), 'RS')
+      assert.equal(merge_flags('RS', 'S'), 'RS')
+      assert.equal(merge_flags('', 'S'), 'S')
+      assert.equal(merge_flags('S', ''), 'S')
+    })
+
+    it('deduplicates and sorts across both inputs', () => {
+      assert.equal(merge_flags('SF', 'RT'), 'FRST')
+      assert.equal(merge_flags('RRR', 'SSS'), 'RS')
+    })
+
+    it('normalizes to uppercase', () => {
+      assert.equal(merge_flags('s', 'r'), 'RS')
+      assert.equal(merge_flags('rS', 'f'), 'FRS')
+    })
+
+    it('drops non-letter characters', () => {
+      assert.equal(merge_flags('S1', 'R!'), 'RS')
+      assert.equal(merge_flags(',', ':2,S'), 'S')
+    })
+  })
+
+  describe('build_maildir_filename', () => {
+    it('returns base alone when flags are empty', () => {
+      assert.equal(build_maildir_filename('vm-abc', ''), 'vm-abc')
+    })
+
+    it('appends :2, prefix when flags are set', () => {
+      assert.equal(build_maildir_filename('vm-abc', 'S'), 'vm-abc:2,S')
+      assert.equal(build_maildir_filename('vm-abc', 'RS'), 'vm-abc:2,RS')
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // 9. mark_read
+  // -----------------------------------------------------------------------
+  describe('mark_read', () => {
+    it('moves a file from new/ to cur/ with default S flag', () => {
+      const filename = write_message(make_message({ text: 'mark-me-read' }))!
+      assert.ok(filename)
+
+      const results = mark_read([filename])
+
+      assert.equal(results.length, 1)
+      assert.equal(results[0].filename, filename)
+      assert.equal(results[0].found, true)
+      assert.equal(results[0].new_filename, `${filename}:2,S`)
+
+      // File should no longer exist in new/
+      assert.equal(readdirSync(join(tmp_dir, 'new')).length, 0)
+      // File should exist in cur/ with :2,S suffix
+      const cur_files = readdirSync(join(tmp_dir, 'cur'))
+      assert.equal(cur_files.length, 1)
+      assert.equal(cur_files[0], `${filename}:2,S`)
+    })
+
+    it('supports custom flag sets and sorts them alphabetically', () => {
+      const filename = write_message(make_message({ text: 'custom-flags' }))!
+      const results = mark_read([filename], 'RS')
+
+      assert.equal(results[0].new_filename, `${filename}:2,RS`)
+
+      // Verify on disk
+      const cur_files = readdirSync(join(tmp_dir, 'cur'))
+      assert.ok(cur_files.includes(`${filename}:2,RS`))
+    })
+
+    it('sorts flags alphabetically even when input is not sorted', () => {
+      const filename = write_message(make_message({ text: 'unsorted-input' }))!
+      const results = mark_read([filename], 'SR')
+
+      // Output must be alphabetically sorted per Maildir spec
+      assert.equal(results[0].new_filename, `${filename}:2,RS`)
+    })
+
+    it('merges with existing flags when called twice', () => {
+      const filename = write_message(make_message({ text: 'merge-flags' }))!
+
+      // First mark: just S
+      const first = mark_read([filename], 'S')
+      assert.equal(first[0].new_filename, `${filename}:2,S`)
+
+      // Second mark: add R -- should merge to RS (pass the already-flagged name)
+      const second = mark_read([`${filename}:2,S`], 'R')
+      assert.equal(second[0].new_filename, `${filename}:2,RS`)
+
+      // Only one file should exist now (merge, not duplicate)
+      assert.equal(readdirSync(join(tmp_dir, 'cur')).length, 1)
+      assert.equal(readdirSync(join(tmp_dir, 'new')).length, 0)
+    })
+
+    it('looks up by base name so the caller can pass either form', () => {
+      const filename = write_message(make_message({ text: 'by-base' }))!
+
+      // First mark to get into cur/ with :2,S suffix
+      mark_read([filename], 'S')
+
+      // Now call again with the *bare* base name (no suffix) -- should still find it
+      const results = mark_read([filename], 'R')
+      assert.equal(results[0].found, true)
+      assert.equal(results[0].new_filename, `${filename}:2,RS`)
+    })
+
+    it('deduplicates repeated flag letters', () => {
+      const filename = write_message(make_message({ text: 'dedup-flags' }))!
+      const results = mark_read([filename], 'SSSRS')
+
+      assert.equal(results[0].new_filename, `${filename}:2,RS`)
+    })
+
+    it('is idempotent when the same flag is applied twice', () => {
+      const filename = write_message(make_message({ text: 'idempotent' }))!
+
+      mark_read([filename], 'S')
+      const second = mark_read([`${filename}:2,S`], 'S')
+
+      assert.equal(second[0].found, true)
+      assert.equal(second[0].new_filename, `${filename}:2,S`)
+      assert.equal(readdirSync(join(tmp_dir, 'cur')).length, 1)
+    })
+
+    it('handles bulk filenames in a single call', () => {
+      const f1 = write_message(make_message({ text: 'bulk-1', timestamp: new Date('2026-04-05T10:00:00Z') }))!
+      const f2 = write_message(make_message({ text: 'bulk-2', timestamp: new Date('2026-04-05T11:00:00Z') }))!
+      const f3 = write_message(make_message({ text: 'bulk-3', timestamp: new Date('2026-04-05T12:00:00Z') }))!
+
+      const results = mark_read([f1, f2, f3], 'S')
+
+      assert.equal(results.length, 3)
+      assert.ok(results.every(r => r.found), 'all three should be found')
+      assert.equal(readdirSync(join(tmp_dir, 'new')).length, 0)
+      assert.equal(readdirSync(join(tmp_dir, 'cur')).length, 3)
+    })
+
+    it('returns found=false for missing filenames without crashing', () => {
+      // Write one real message
+      const real = write_message(make_message({ text: 'real' }))!
+
+      const results = mark_read([real, 'vm-doesnotexist'], 'S')
+
+      assert.equal(results.length, 2)
+      assert.equal(results[0].found, true)
+      assert.equal(results[1].found, false)
+      assert.equal(results[1].new_filename, null)
+    })
+
+    it('rejects filenames with path traversal', () => {
+      const results = mark_read(['../../etc/passwd', '../secret', 'subdir/file'], 'S')
+
+      assert.equal(results.length, 3)
+      assert.ok(results.every(r => !r.found), 'all path-traversal attempts should fail')
+      assert.ok(results.every(r => r.new_filename === null))
+    })
+
+    it('creates cur/ directory if it does not already exist', () => {
+      const filename = write_message(make_message({ text: 'no-cur-yet' }))!
+
+      // Remove cur/ to simulate a fresh maildir (write_message creates it but let's be sure)
+      rmSync(join(tmp_dir, 'cur'), { recursive: true, force: true })
+      assert.equal(readdirSync(tmp_dir).includes('cur'), false)
+
+      const results = mark_read([filename], 'S')
+      assert.equal(results[0].found, true)
+      assert.ok(readdirSync(tmp_dir).includes('cur'))
+      assert.equal(readdirSync(join(tmp_dir, 'cur')).length, 1)
+    })
+
+    it('accepts flag letters in mixed case', () => {
+      const filename = write_message(make_message({ text: 'mixed-case' }))!
+      const results = mark_read([filename], 'rs')
+
+      assert.equal(results[0].new_filename, `${filename}:2,RS`)
     })
   })
 })

--- a/maildir.test.ts
+++ b/maildir.test.ts
@@ -19,6 +19,8 @@ import {
   parse_maildir_filename,
   merge_flags,
   build_maildir_filename,
+  truncate_body,
+  TRUNCATION_MARKER,
 } from './maildir.js'
 import type { VoiceMessage } from './maildir.js'
 
@@ -180,8 +182,8 @@ describe('maildir', () => {
       const agent_a_inbound = list_messages({ agent_session_id: 'agent-A', direction: 'inbound' })
       assert.equal(agent_a_inbound.length, 1, 'Should find 1 inbound message for agent-A')
 
-      // All sessions (no agent_session_id filter)
-      const all = list_messages({})
+      // All sessions (no agent_session_id filter) -- include bodies to check content
+      const all = list_messages({ include_body: true })
       assert.equal(all.length, 4, 'Should find all 4 messages without filters')
 
       // Verify sort order (newest first)
@@ -189,7 +191,7 @@ describe('maildir', () => {
       assert.ok(all[3].body.includes('msg-1'), 'Last message should be oldest (msg-1)')
 
       // Limit
-      const limited = list_messages({ limit: 2 })
+      const limited = list_messages({ limit: 2, include_body: true })
       assert.equal(limited.length, 2, 'Limit should restrict result count')
       assert.ok(limited[0].body.includes('msg-4'), 'Limited results should still be newest first')
     })
@@ -585,4 +587,173 @@ describe('maildir', () => {
       assert.ok(cur_files.every(name => name.endsWith(':2,RS')))
     })
   })
+
+  // -----------------------------------------------------------------------
+  // 10. truncate_body (pure helper)
+  // -----------------------------------------------------------------------
+  describe('truncate_body', () => {
+    it('returns body unchanged when shorter than limit', () => {
+      assert.equal(truncate_body('hello', 2000), 'hello')
+    })
+
+    it('returns body unchanged when exactly at limit', () => {
+      const body = 'a'.repeat(10)
+      assert.equal(truncate_body(body, 10), body)
+    })
+
+    it('truncates and appends marker when body exceeds limit', () => {
+      const body = 'a'.repeat(50)
+      const result = truncate_body(body, 10)
+      assert.ok(result.startsWith('a'.repeat(10)))
+      assert.ok(result.endsWith(TRUNCATION_MARKER))
+    })
+
+    it('returns body unchanged when max_length is 0 (unlimited)', () => {
+      const body = 'x'.repeat(100000)
+      assert.equal(truncate_body(body, 0), body)
+    })
+
+    it('treats negative max_length as unlimited', () => {
+      const body = 'hello world'
+      assert.equal(truncate_body(body, -1), body)
+    })
+
+    it('does not append marker on empty body', () => {
+      assert.equal(truncate_body('', 100), '')
+      assert.equal(truncate_body('', 0), '')
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // 11. list_messages: include_body, body_max_length, unread filter
+  // -----------------------------------------------------------------------
+  describe('list_messages include_body and body_max_length', () => {
+    it('omits bodies by default (include_body: false)', () => {
+      write_message(make_message({ text: 'body text here' }))
+
+      const messages = list_messages({})
+      assert.equal(messages.length, 1)
+      assert.equal(messages[0].body, '', 'body should be empty string when include_body is false')
+    })
+
+    it('returns full body when include_body: true and body is under limit', () => {
+      write_message(make_message({ text: 'short body' }))
+
+      const messages = list_messages({ include_body: true })
+      assert.equal(messages.length, 1)
+      assert.equal(messages[0].body, 'short body')
+    })
+
+    it('truncates bodies past body_max_length with a clear marker', () => {
+      // Make a body longer than the truncation limit
+      const long_text = 'X'.repeat(100)
+      write_message(make_message({ text: long_text }))
+
+      const messages = list_messages({ include_body: true, body_max_length: 20 })
+      assert.equal(messages.length, 1)
+      assert.ok(messages[0].body.startsWith('X'.repeat(20)))
+      assert.ok(messages[0].body.endsWith(TRUNCATION_MARKER))
+      // The truncated content length should be 20 + newline + marker
+      assert.equal(messages[0].body.length, 20 + 1 + TRUNCATION_MARKER.length)
+    })
+
+    it('body_max_length: 0 returns full body without truncation', () => {
+      const long_text = 'Z'.repeat(10000)
+      write_message(make_message({ text: long_text }))
+
+      const messages = list_messages({ include_body: true, body_max_length: 0 })
+      assert.equal(messages.length, 1)
+      assert.equal(messages[0].body, long_text, 'body_max_length: 0 should return full body')
+      assert.ok(!messages[0].body.includes(TRUNCATION_MARKER), 'no truncation marker on unlimited')
+    })
+
+    it('default body_max_length is 2000 when include_body is true', () => {
+      const long_text = 'A'.repeat(3000)
+      write_message(make_message({ text: long_text }))
+
+      const messages = list_messages({ include_body: true })
+      assert.equal(messages.length, 1)
+      assert.ok(messages[0].body.length < 3000, 'body should be truncated by default 2000 limit')
+      assert.ok(messages[0].body.startsWith('A'.repeat(2000)))
+      assert.ok(messages[0].body.endsWith(TRUNCATION_MARKER))
+    })
+
+    it('returns bodies for bulk reads across multiple messages', () => {
+      write_message(make_message({ text: 'msg one', timestamp: new Date('2026-04-05T10:00:00Z') }))
+      write_message(make_message({ text: 'msg two', timestamp: new Date('2026-04-05T11:00:00Z') }))
+      write_message(make_message({ text: 'msg three', timestamp: new Date('2026-04-05T12:00:00Z') }))
+
+      const messages = list_messages({ include_body: true })
+      assert.equal(messages.length, 3)
+      // Sorted newest first
+      assert.equal(messages[0].body, 'msg three')
+      assert.equal(messages[1].body, 'msg two')
+      assert.equal(messages[2].body, 'msg one')
+    })
+  })
+
+  describe('list_messages unread filter', () => {
+    it('defaults to both read and unread (unread: undefined)', () => {
+      const f1 = write_message(make_message({ text: 'unread-1', timestamp: new Date('2026-04-05T10:00:00Z') }))!
+      const f2 = write_message(make_message({ text: 'read-2', timestamp: new Date('2026-04-05T11:00:00Z') }))!
+      // Mark f2 as seen
+      mark_read([f2], 'S')
+
+      const all = list_messages({})
+      assert.equal(all.length, 2, 'both messages should be returned when unread is omitted')
+    })
+
+    it('unread: true returns messages in new/ and cur/ files without S flag', () => {
+      const f1 = write_message(make_message({ text: 'still-unread-in-new', timestamp: new Date('2026-04-05T10:00:00Z') }))!
+      const f2 = write_message(make_message({ text: 'seen-in-cur', timestamp: new Date('2026-04-05T11:00:00Z') }))!
+      const f3 = write_message(make_message({ text: 'replied-but-not-seen', timestamp: new Date('2026-04-05T12:00:00Z') }))!
+
+      // f2 -> marked as Seen (S flag, moves to cur/)
+      mark_read([f2], 'S')
+      // f3 -> marked as Replied only (R flag, moves to cur/ but no S, so still unread)
+      mark_read([f3], 'R')
+
+      const unread = list_messages({ unread: true })
+      assert.equal(unread.length, 2, 'unread should include new/ file and cur/ file without S')
+      const bodies_present = unread.map(m => m.filename).sort()
+      // f1 is still in new/ with no flags; f3 is in cur/ with :2,R
+      assert.ok(bodies_present.some(n => n === f1), 'new/ file should be in unread list')
+      assert.ok(bodies_present.some(n => n === `${f3}:2,R`), 'cur/ file without S should be in unread list')
+    })
+
+    it('unread: false returns only read messages (cur/ files with S flag)', () => {
+      const f1 = write_message(make_message({ text: 'u-1', timestamp: new Date('2026-04-05T10:00:00Z') }))!
+      const f2 = write_message(make_message({ text: 'seen-1', timestamp: new Date('2026-04-05T11:00:00Z') }))!
+      const f3 = write_message(make_message({ text: 'seen-replied', timestamp: new Date('2026-04-05T12:00:00Z') }))!
+
+      mark_read([f2], 'S')
+      mark_read([f3], 'RS')
+
+      const read = list_messages({ unread: false })
+      assert.equal(read.length, 2, 'should return only messages with S flag')
+      const names = read.map(m => m.filename).sort()
+      assert.ok(names.some(n => n === `${f2}:2,S`))
+      assert.ok(names.some(n => n === `${f3}:2,RS`))
+    })
+
+    it('unread filter composes with include_body and body_max_length', () => {
+      const f1 = write_message(make_message({ text: 'unread body content', timestamp: new Date('2026-04-05T10:00:00Z') }))!
+      const f2 = write_message(make_message({ text: 'read body content', timestamp: new Date('2026-04-05T11:00:00Z') }))!
+      mark_read([f2], 'S')
+
+      const unread = list_messages({ unread: true, include_body: true, body_max_length: 0 })
+      assert.equal(unread.length, 1)
+      assert.equal(unread[0].body, 'unread body content')
+    })
+
+    it('unread filter returns empty list when all messages are read', () => {
+      const f1 = write_message(make_message({ text: 'one', timestamp: new Date('2026-04-05T10:00:00Z') }))!
+      const f2 = write_message(make_message({ text: 'two', timestamp: new Date('2026-04-05T11:00:00Z') }))!
+      mark_read([f1, f2], 'S')
+
+      const unread = list_messages({ unread: true })
+      assert.equal(unread.length, 0)
+    })
+  })
+
 })

--- a/maildir.test.ts
+++ b/maildir.test.ts
@@ -21,6 +21,7 @@ import {
   build_maildir_filename,
   truncate_body,
   TRUNCATION_MARKER,
+  count_unread,
 } from './maildir.js'
 import type { VoiceMessage } from './maildir.js'
 
@@ -753,6 +754,136 @@ describe('maildir', () => {
 
       const unread = list_messages({ unread: true })
       assert.equal(unread.length, 0)
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // 12. count_unread
+  // -----------------------------------------------------------------------
+  describe('count_unread', () => {
+    it('returns 0 when the Maildir is empty', () => {
+      assert.equal(count_unread(), 0)
+    })
+
+    it('returns 0 when the Maildir directories do not exist', () => {
+      // tmp_dir exists but has no new/cur subdirs yet
+      assert.equal(count_unread(), 0)
+    })
+
+    it('counts files in new/ (all unread)', () => {
+      write_message(make_message({ text: 'one', timestamp: new Date('2026-04-05T10:00:00Z') }))
+      write_message(make_message({ text: 'two', timestamp: new Date('2026-04-05T11:00:00Z') }))
+      write_message(make_message({ text: 'three', timestamp: new Date('2026-04-05T12:00:00Z') }))
+
+      assert.equal(count_unread(), 3)
+    })
+
+    it('skips cur/ files with the S flag', () => {
+      const f1 = write_message(make_message({ text: 'keep-unread', timestamp: new Date('2026-04-05T10:00:00Z') }))!
+      const f2 = write_message(make_message({ text: 'mark-seen', timestamp: new Date('2026-04-05T11:00:00Z') }))!
+
+      mark_read([f2], 'S')
+
+      // f1 still unread in new/, f2 is seen in cur/ -- count should be 1
+      assert.equal(count_unread(), 1)
+    })
+
+    it('counts cur/ files that have flags but no S (e.g. :2,R)', () => {
+      const f1 = write_message(make_message({ text: 'replied-not-seen', timestamp: new Date('2026-04-05T10:00:00Z') }))!
+
+      // Apply just R -- file moves to cur/ but is still unread (no S)
+      mark_read([f1], 'R')
+
+      assert.equal(count_unread(), 1)
+    })
+
+    it('counts :2,RS files as read (S present)', () => {
+      const f1 = write_message(make_message({ text: 'seen-and-replied', timestamp: new Date('2026-04-05T10:00:00Z') }))!
+
+      mark_read([f1], 'RS')
+
+      assert.equal(count_unread(), 0)
+    })
+
+    it('combines new/ and cur/ counts correctly', () => {
+      const f1 = write_message(make_message({ text: 'a', timestamp: new Date('2026-04-05T10:00:00Z') }))!
+      const f2 = write_message(make_message({ text: 'b', timestamp: new Date('2026-04-05T11:00:00Z') }))!
+      const f3 = write_message(make_message({ text: 'c', timestamp: new Date('2026-04-05T12:00:00Z') }))!
+      const f4 = write_message(make_message({ text: 'd', timestamp: new Date('2026-04-05T13:00:00Z') }))!
+
+      mark_read([f2], 'S')       // read
+      mark_read([f3], 'R')       // still unread (no S)
+      mark_read([f4], 'RS')      // read (S present)
+
+      // Unread: f1 (new/) + f3 (cur/ :2,R) = 2
+      assert.equal(count_unread(), 2)
+    })
+
+    it('ignores non-vm- files in new/ and cur/', () => {
+      // Write one real vm message
+      write_message(make_message({ text: 'real', timestamp: new Date('2026-04-05T10:00:00Z') }))
+
+      // Drop in a junk file in new/ that shouldn't be counted
+      writeFileSync(join(tmp_dir, 'new', '.hidden'), 'not a vm message')
+      writeFileSync(join(tmp_dir, 'new', 'other-prefix-file'), 'not a vm message')
+
+      // And one in cur/ that also should not be counted
+      mkdirSync(join(tmp_dir, 'cur'), { recursive: true })
+      writeFileSync(join(tmp_dir, 'cur', 'stranger-file'), 'not a vm message')
+
+      assert.equal(count_unread(), 1, 'only the vm- file should be counted')
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // 13. R flag on reply (mark_read with 'R' flag)
+  // -----------------------------------------------------------------------
+  describe('R flag application', () => {
+    it('applies R flag to a new/ message (moves it to cur/ with :2,R)', () => {
+      const filename = write_message(make_message({ text: 'please-reply' }))!
+
+      const results = mark_read([filename], 'R')
+
+      assert.equal(results.length, 1)
+      assert.equal(results[0].found, true)
+      assert.equal(results[0].new_filename, `${filename}:2,R`)
+
+      // File moved out of new/ into cur/ with just the R flag
+      assert.equal(readdirSync(join(tmp_dir, 'new')).length, 0)
+      assert.ok(readdirSync(join(tmp_dir, 'cur')).includes(`${filename}:2,R`))
+    })
+
+    it('merges R flag with existing S flag to yield :2,RS', () => {
+      const filename = write_message(make_message({ text: 'seen-then-replied' }))!
+
+      // First read marks it Seen
+      read_message(filename)
+      assert.ok(readdirSync(join(tmp_dir, 'cur')).includes(`${filename}:2,S`))
+
+      // Now reply fires -- apply R flag. Caller can pass the bare filename (base-name lookup)
+      const results = mark_read([filename], 'R')
+
+      assert.equal(results[0].found, true)
+      assert.equal(results[0].new_filename, `${filename}:2,RS`)
+      assert.ok(readdirSync(join(tmp_dir, 'cur')).includes(`${filename}:2,RS`))
+      assert.equal(readdirSync(join(tmp_dir, 'cur')).length, 1, 'no duplicate files after merge')
+    })
+
+    it('R flag on an already-replied message is idempotent', () => {
+      const filename = write_message(make_message({ text: 'double-reply' }))!
+
+      mark_read([filename], 'R')
+      const second = mark_read([filename], 'R')
+
+      assert.equal(second[0].found, true)
+      assert.equal(second[0].new_filename, `${filename}:2,R`)
+      assert.equal(readdirSync(join(tmp_dir, 'cur')).length, 1)
+    })
+
+    it('R flag returns found=false for missing source message', () => {
+      const results = mark_read(['vm-never-existed'], 'R')
+      assert.equal(results[0].found, false)
+      assert.equal(results[0].new_filename, null)
     })
   })
 

--- a/maildir.ts
+++ b/maildir.ts
@@ -158,40 +158,84 @@ function to_maildir_message(filename: string, headers: Record<string, string>, b
  * resolved path is within the Maildir directory. Only returns messages
  * with X-Transport: voicemode-connect header.
  *
+ * Base-name lookup: the caller can pass either the bare filename or an
+ * already-flagged `:2,FLAGS` form -- we look up by base name across new/
+ * and cur/, matching the behaviour of mark_read.
+ *
+ * By default, a successful read marks the message as Seen (moves to cur/
+ * with S flag). Pass `{ mark_read: false }` to opt out. The returned
+ * MaildirMessage's `filename` field reflects the on-disk name after any
+ * rename (so callers can use it for subsequent operations).
+ *
  * Returns null if the file doesn't exist, fails security checks, or
  * has the wrong X-Transport header.
  */
-export function read_message(filename: string): MaildirMessage | null {
+export function read_message(
+  filename: string,
+  options: { mark_read?: boolean } = {},
+): MaildirMessage | null {
   // Path traversal prevention: reject suspicious filenames
   if (filename.includes('..') || filename.includes('/')) return null
 
+  const { mark_read: should_mark = true } = options
+
   const maildir = get_maildir_path()
   const maildir_resolved = resolve(maildir)
+  const { base } = parse_maildir_filename(filename)
 
-  // Check new/ and cur/ directories
+  // Locate the file by base name across new/ and cur/ (handles flag suffix drift)
+  let found_path: string | null = null
+  let found_name: string | null = null
+
   for (const sub of ['new', 'cur']) {
-    const file_path = join(maildir, sub, filename)
-    const resolved_path = resolve(file_path)
+    const dir_path = join(maildir, sub)
+    if (!existsSync(dir_path)) continue
 
-    // Verify resolved path is within the Maildir directory
-    if (!resolved_path.startsWith(maildir_resolved + '/')) continue
-
-    if (!existsSync(resolved_path)) continue
-
+    let entries: string[]
     try {
-      const raw = readFileSync(resolved_path, 'utf8')
-      const { headers, body } = parse_message(raw)
-
-      // Only return messages with the correct transport header
-      if (headers['X-Transport'] !== 'voicemode-connect') return null
-
-      return to_maildir_message(filename, headers, body)
+      entries = readdirSync(dir_path)
     } catch {
-      return null
+      continue
+    }
+
+    for (const entry of entries) {
+      if (parse_maildir_filename(entry).base !== base) continue
+      const candidate = join(dir_path, entry)
+      const resolved = resolve(candidate)
+      // Verify resolved path is within the Maildir directory
+      if (!resolved.startsWith(maildir_resolved + '/')) continue
+      found_path = resolved
+      found_name = entry
+      break
+    }
+    if (found_path) break
+  }
+
+  if (!found_path || !found_name) return null
+
+  let raw: string
+  try {
+    raw = readFileSync(found_path, 'utf8')
+  } catch {
+    return null
+  }
+
+  const { headers, body } = parse_message(raw)
+
+  // Only return messages with the correct transport header
+  if (headers['X-Transport'] !== 'voicemode-connect') return null
+
+  // Apply S flag (and move new/ -> cur/) unless opted out
+  let effective_name = found_name
+  if (should_mark) {
+    const results = mark_read([found_name], 'S')
+    const result = results[0]
+    if (result && result.found && result.new_filename) {
+      effective_name = result.new_filename
     }
   }
 
-  return null
+  return to_maildir_message(effective_name, headers, body)
 }
 
 /**

--- a/maildir.ts
+++ b/maildir.ts
@@ -395,6 +395,43 @@ export function build_maildir_filename(base: string, flags: string): string {
   return flags.length === 0 ? base : `${base}:2,${flags}`
 }
 
+/**
+ * Count unread messages in the Maildir.
+ *
+ * Unread = files in new/ (never touched) + files in cur/ without the S flag.
+ * Filters by filename prefix `vm-` so we don't have to read file contents to
+ * decide whether a file is a voicemode-channel message -- keeps the counter
+ * cheap enough to call on every status check / notification append.
+ */
+export function count_unread(): number {
+  const maildir = get_maildir_path()
+  let count = 0
+
+  // new/ -- every vm-* file is unread by definition
+  const new_dir = join(maildir, 'new')
+  if (existsSync(new_dir)) {
+    try {
+      for (const entry of readdirSync(new_dir)) {
+        if (entry.startsWith('vm-')) count++
+      }
+    } catch { /* ignore */ }
+  }
+
+  // cur/ -- vm-* files without the S flag are still unread
+  const cur_dir = join(maildir, 'cur')
+  if (existsSync(cur_dir)) {
+    try {
+      for (const entry of readdirSync(cur_dir)) {
+        if (!entry.startsWith('vm-')) continue
+        const { flags } = parse_maildir_filename(entry)
+        if (!flags.includes('S')) count++
+      }
+    } catch { /* ignore */ }
+  }
+
+  return count
+}
+
 export interface MarkReadResult {
   /** The filename as passed in by the caller. */
   filename: string

--- a/maildir.ts
+++ b/maildir.ts
@@ -262,3 +262,153 @@ export function list_messages(options: {
 
   return messages.slice(0, limit)
 }
+
+// ---------------------------------------------------------------------------
+// Maildir flag operations (mark_read)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a Maildir filename into its base and flag components.
+ *
+ * Maildir spec: filenames in cur/ use the form `<base>:2,<flags>` where flags
+ * are ASCII letters sorted alphabetically (e.g. "RS" = Replied + Seen).
+ * Files in new/ typically have no suffix.
+ *
+ * Only the experimental `:2,` variant is recognized -- `:1,` filenames are
+ * treated as having no flags, since that form is not used by notmuch/neomutt.
+ */
+export function parse_maildir_filename(filename: string): { base: string; flags: string } {
+  const marker = ':2,'
+  const idx = filename.lastIndexOf(marker)
+  if (idx < 0) return { base: filename, flags: '' }
+  return { base: filename.slice(0, idx), flags: filename.slice(idx + marker.length) }
+}
+
+/**
+ * Merge two flag strings into a single set of unique, alphabetically sorted
+ * uppercase ASCII-letter flags.
+ *
+ * Non-letter characters are dropped. Case is normalized to uppercase.
+ * Duplicates are removed. Output is sorted (standard Maildir flag order).
+ */
+export function merge_flags(existing: string, new_flags: string): string {
+  const letters = new Set<string>()
+  for (const ch of (existing + new_flags).toUpperCase()) {
+    if (ch >= 'A' && ch <= 'Z') letters.add(ch)
+  }
+  return Array.from(letters).sort().join('')
+}
+
+/**
+ * Build a full Maildir filename from its base and flag components.
+ * When flags is empty, returns just the base (suitable for new/ files).
+ */
+export function build_maildir_filename(base: string, flags: string): string {
+  return flags.length === 0 ? base : `${base}:2,${flags}`
+}
+
+export interface MarkReadResult {
+  /** The filename as passed in by the caller. */
+  filename: string
+  /** New filename (with flags applied) if the file was found and renamed. */
+  new_filename: string | null
+  /** True if the file was located in new/ or cur/. */
+  found: boolean
+}
+
+/**
+ * Mark one or more messages with Maildir flags, moving them from new/ to cur/.
+ *
+ * For each filename:
+ *   1. Locate the file by its base name (with or without a :2,FLAGS suffix)
+ *      in either new/ or cur/.
+ *   2. Merge the requested flags with any existing flags (unique, sorted).
+ *   3. Rename the file to `<base>:2,<flags>` in cur/.
+ *
+ * Security: filenames containing '..' or '/' are rejected (returns found=false).
+ *
+ * Idempotent: marking an already-marked file with the same flags is a no-op
+ * rename (the file is already in cur/ with those flags).
+ *
+ * @param filenames Basenames of Maildir files (as returned by list_messages)
+ * @param flags Letters to apply (default "S" = Seen). Case-insensitive.
+ * @returns One result per input filename, in the same order.
+ */
+export function mark_read(filenames: string[], flags: string = 'S'): MarkReadResult[] {
+  const maildir = get_maildir_path()
+  const maildir_resolved = resolve(maildir)
+  const cur_dir = join(maildir, 'cur')
+
+  // Ensure cur/ exists (may not if nothing has been marked yet)
+  mkdirSync(cur_dir, { recursive: true })
+
+  const results: MarkReadResult[] = []
+
+  for (const filename of filenames) {
+    // Path traversal prevention
+    if (filename.includes('..') || filename.includes('/')) {
+      results.push({ filename, new_filename: null, found: false })
+      continue
+    }
+
+    const { base } = parse_maildir_filename(filename)
+
+    // Search both new/ and cur/ for a file whose base matches.
+    // The on-disk name may differ from `filename` if flags were previously applied.
+    let found_path: string | null = null
+    let found_sub: string | null = null
+    let found_name: string | null = null
+
+    for (const sub of ['new', 'cur']) {
+      const dir_path = join(maildir, sub)
+      if (!existsSync(dir_path)) continue
+
+      let entries: string[]
+      try {
+        entries = readdirSync(dir_path)
+      } catch {
+        continue
+      }
+
+      for (const entry of entries) {
+        if (parse_maildir_filename(entry).base === base) {
+          const candidate = join(dir_path, entry)
+          const resolved = resolve(candidate)
+          // Verify resolved path is within the Maildir directory
+          if (!resolved.startsWith(maildir_resolved + '/')) continue
+          found_path = resolved
+          found_sub = sub
+          found_name = entry
+          break
+        }
+      }
+      if (found_path) break
+    }
+
+    if (!found_path || !found_sub || !found_name) {
+      results.push({ filename, new_filename: null, found: false })
+      continue
+    }
+
+    // Merge existing flags with requested flags
+    const existing_flags = parse_maildir_filename(found_name).flags
+    const merged = merge_flags(existing_flags, flags)
+    const new_name = build_maildir_filename(base, merged)
+    const new_path = join(cur_dir, new_name)
+
+    // If source == destination, it's a no-op (already marked in cur/)
+    if (found_path === resolve(new_path)) {
+      results.push({ filename, new_filename: new_name, found: true })
+      continue
+    }
+
+    try {
+      renameSync(found_path, new_path)
+      results.push({ filename, new_filename: new_name, found: true })
+    } catch {
+      results.push({ filename, new_filename: null, found: false })
+    }
+  }
+
+  return results
+}

--- a/maildir.ts
+++ b/maildir.ts
@@ -238,11 +238,36 @@ export function read_message(
   return to_maildir_message(effective_name, headers, body)
 }
 
+/** Marker appended to bodies that exceed body_max_length. */
+export const TRUNCATION_MARKER = '... [truncated]'
+
 /**
- * List messages from the Maildir, filtered by session and direction.
+ * Truncate a body string to at most `max_length` characters, appending a
+ * clear marker when truncation happens. A `max_length` of 0 means unlimited
+ * (returns the body unchanged). Negative values are treated as 0.
+ */
+export function truncate_body(body: string, max_length: number): string {
+  if (max_length <= 0) return body
+  if (body.length <= max_length) return body
+  return body.slice(0, max_length) + '\n' + TRUNCATION_MARKER
+}
+
+/**
+ * List messages from the Maildir, filtered by session, direction, and read state.
  *
  * Scans both new/ and cur/ directories. Only includes messages with
  * X-Transport: voicemode-connect header.
+ *
+ * Options:
+ *   - include_body: when false (default), returned messages have body=''
+ *     to keep responses compact. Set true to return bodies (truncated by
+ *     body_max_length).
+ *   - body_max_length: maximum body length when include_body is true.
+ *     Default 2000. Pass 0 for unlimited. Bodies past the limit get a
+ *     "... [truncated]" marker appended.
+ *   - unread: undefined (default) returns both read and unread. true
+ *     returns only unread messages (in new/, or in cur/ without S flag).
+ *     false returns only read messages (in cur/ with S flag).
  *
  * Returns messages sorted by date descending (newest first).
  */
@@ -250,8 +275,18 @@ export function list_messages(options: {
   agent_session_id?: string
   direction?: 'inbound' | 'outbound'
   limit?: number
+  include_body?: boolean
+  body_max_length?: number
+  unread?: boolean
 }): MaildirMessage[] {
-  const { agent_session_id, direction, limit = 50 } = options
+  const {
+    agent_session_id,
+    direction,
+    limit = 50,
+    include_body = false,
+    body_max_length = 2000,
+    unread,
+  } = options
   const maildir = get_maildir_path()
   const messages: MaildirMessage[] = []
 
@@ -269,6 +304,13 @@ export function list_messages(options: {
     for (const filename of filenames) {
       // Skip hidden files and non-vm files
       if (filename.startsWith('.')) continue
+
+      // Unread filter: file is unread if it's in new/, or in cur/ without the S flag.
+      if (unread !== undefined) {
+        const { flags } = parse_maildir_filename(filename)
+        const is_unread = sub === 'new' || !flags.includes('S')
+        if (is_unread !== unread) continue
+      }
 
       const file_path = join(dir_path, filename)
       let raw: string
@@ -289,7 +331,9 @@ export function list_messages(options: {
       // Filter by direction if provided
       if (direction && headers['X-VoiceMode-Direction'] !== direction) continue
 
-      messages.push(to_maildir_message(filename, headers, body))
+      const msg = to_maildir_message(filename, headers, body)
+      msg.body = include_body ? truncate_body(body, body_max_length) : ''
+      messages.push(msg)
     }
   }
 


### PR DESCRIPTION
## Summary

Adds Maildir message-state tracking to voicemode-channel: mark_read flags, bulk-body reads, unread filter, and automatic R-flag-on-reply. Builds on VMC-452 (Maildir persistence).

Implemented in four stages as separate commits:

1. **impl-001** -- `mark_read` core: flag-suffix renaming, `new/` → `cur/` move, helpers (`parse_maildir_filename`, `merge_flags`, `build_maildir_filename`)
2. **impl-002** -- `read_message` auto-marks as read (with opt-out), new `mark_read` MCP tool for bulk operations
3. **impl-003** -- `list_messages` gains `include_body`, `body_max_length` (0 = unlimited, truncation marker), and `unread` filter
4. **impl-004** -- `reply` tool takes optional `in_reply_to` and applies R flag; `status` tool now reports unread count

All four stages built by fresh workers per harness feature, with verification between each.

## What the LLM sees now

Five MCP tools (previously four):
- `reply` (now with `in_reply_to` for R-flag attribution)
- `status` (now includes unread count)
- `profile`
- `list_messages` (now with `include_body`, `body_max_length`, `unread`)
- `read_message` (now with `mark_read` opt-out)
- **new:** `mark_read` (bulk filenames + custom flag set)

## Maildir semantics

Standard `:2,FLAGS` filename suffixes (S=Seen, R=Replied). Files move from `new/` to `cur/` when flagged. Verified against:
- `notmuch new` -- `unread` tag drops when S flag is applied, `replied` tag appears with R
- Python stdlib `mailbox.Maildir` -- independent implementation reads flags identically
- Neomutt integration implicit via shared `:2,FLAGS` standard

## Test plan

- [x] 65 unit tests pass (make test)
- [x] tsc build clean, npm pack + auth smoke test pass
- [x] Manual notmuch integration check
- [x] All 9 task acceptance criteria verified against code

## Harness

VMC-490 ran through a 6-feature harness (ready + 4 impl + verify), fresh worker per feature. Task reviewed at B+ (87%) before implementation; fixes applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)