### PR TITLE
chore: gitignore test artifacts (coverage/, session-notes/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ dist/
 !start.sh
 .DS_Store
 .voicemode.env
+
+# Test artifacts
+coverage/
+session-notes/


### PR DESCRIPTION
Both directories get created during make test runs and shouldn't be committed:

- coverage/: Node's --experimental-test-coverage JSON output
- session-notes/: auto-created if a worker calls session-notes inside the worktree

Noticed while prepping VMC-490 for merge -- worker's worktree had a session-notes/ folder, main worktree had a coverage/ folder. Both were polluting git status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)