### PR TITLE
docs(changelog): fold read_message auto-mark into Added entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,38 @@ All notable changes to the VoiceMode Channel plugin will be documented in this f
 
 ## [Unreleased]
 
+### Added
+
+- **Maildir persistence** -- inbound voice messages and outbound replies are now written to `~/.voicemode/maildir/channel/` in standard Maildir format, so conversation history survives across agent sessions (VMC-452)
+- **Conversation history MCP tools** -- `list_messages` to browse the Maildir inbox and `read_message` to read a message by filename (VMC-452)
+- **Read/unread state tracking** -- messages move from `new/` to `cur/` when read, following the Maildir `:2,FLAGS` standard (S=Seen, R=Replied) that notmuch and neomutt read natively (VMC-490)
+- **`mark_read` MCP tool** -- mark one or more messages read in bulk, with a custom flag set for marking replied, flagged, or other states (VMC-490)
+- **Bulk body reads** -- `list_messages` now takes `include_body` (default false) and `body_max_length` (default 2000, 0 = unlimited) with a clear truncation marker, so agents can fetch many messages in one call (VMC-490)
+- **Unread filter** -- `list_messages` accepts `unread` (true/false/undefined) to filter by read state (VMC-490)
+- **Unread count in status** -- the `status` tool now reports the number of unread messages, supporting notification-append patterns (VMC-490)
+- **R-flag on reply** -- the `reply` tool accepts an optional `in_reply_to` filename and stamps the source message with the Replied flag (VMC-490)
+- **Persistence configuration** -- `VOICEMODE_MAILDIR_PATH` and `VOICEMODE_MAILDIR_ENABLED` environment variables control the Maildir location and whether persistence is active
+
+### Changed
+
+- **`read_message` auto-marks as read** -- default behaviour is to mark the message read on successful fetch; pass `mark_read: false` to opt out (VMC-490)
+
+### Security
+
+- Filename path-traversal protection on all Maildir operations (rejects `..` and `/` in filenames; resolves paths within the Maildir root)
+- Content-hash deduplication prevents duplicate writes for identical messages
+
 ## [0.2.1] - 2026-04-04
 
 ### Fixed
+
 - Version display now reads from package.json instead of hardcoded string
 - Removed dead `createConnection` import from auth.ts
 
 ## [0.2.0] - 2026-04-04
 
 ### Added
+
 - **Built-in Auth0 PKCE login** -- native login flow, no Python voicemode dependency needed (VMC-448)
 - **CLI auth subcommands** -- `voicemode-channel auth login/logout/status` for credential management
 - **Auto-login on first start** -- opens browser if no credentials found
@@ -25,6 +48,7 @@ All notable changes to the VoiceMode Channel plugin will be documented in this f
 - **CLAUDE.md** -- project context for Claude Code
 
 ### Changed
+
 - Extracted shared credentials module from gateway.ts (`credentials.ts`)
 - Moved tsx from runtime to dev dependency
 - Entry point shebang changed to `#!/usr/bin/env node`
@@ -32,9 +56,11 @@ All notable changes to the VoiceMode Channel plugin will be documented in this f
 - Track `package-lock.json` for reproducible installs
 
 ### Fixed
+
 - Include `project_path` in `capabilities_update` user entry (VMC-302)
 
 ### Security
+
 - **Fix reflected XSS** in OAuth callback page -- HTML-escape `error_description` parameter
 - **Tighten directory permissions** -- `~/.voicemode/` created with mode 0700 (was 0755)
 - **Restrict env parser** -- `voicemode.env` only accepts `VOICEMODE_` prefixed keys
@@ -48,9 +74,11 @@ All notable changes to the VoiceMode Channel plugin will be documented in this f
 ## [0.1.6] - 2026-03-25
 
 ### Added
+
 - **Profile voice as reply default** -- reply tool now uses the agent's profile voice when no voice parameter is specified, so agents keep their configured voice identity
 
 ### Fixed
+
 - **Security:** Replace `execSync` with `execFileSync` in `get_project_context` -- eliminates shell injection surface
 - **Security:** Add WebSocket `maxPayload` limit (1 MB) -- prevents memory exhaustion from oversized payloads
 - **Security:** Add transcript length limit and remove `project_path` from `capabilities_update`
@@ -58,22 +86,26 @@ All notable changes to the VoiceMode Channel plugin will be documented in this f
 - **Reliability:** Guard against concurrent `start()` calls; cancellable backoff sleep for prompt shutdown
 
 ### Changed
+
 - Tighten TypeScript types and update `.gitignore`
 - Plugin packaging robustness and documentation fixes
 
 ## [0.1.5] - 2026-03-25
 
 ### Fixed
+
 - **Pre-flight checks in start.sh** -- validates Node.js version, npm packages, and required env vars before starting, with clear error messages
 
 ## [0.1.4] - 2026-03-24
 
 ### Added
+
 - Session ID (`session_id`) included in `capabilities_update` for multi-session coexistence
 
 ## [0.1.3] - 2026-03-24
 
 ### Added
+
 - **Profile tool** -- `profile` MCP tool for dynamic agent identity management
   - Call with no args to read current profile (name, display_name, context, voice, presence)
   - Call with fields to update and push capabilities_update to gateway in real-time
@@ -83,6 +115,7 @@ All notable changes to the VoiceMode Channel plugin will be documented in this f
 - Profile re-sent on gateway reconnect (survives connection drops)
 
 ### Changed
+
 - Exported `ProfileData` interface and `get_project_context()` from gateway module
 - `GatewayClient.send_capabilities_update()` now accepts profile data parameter
 - Refactored tool handlers into separate functions (handle_reply_tool, handle_profile_tool)
@@ -90,21 +123,25 @@ All notable changes to the VoiceMode Channel plugin will be documented in this f
 ## [0.1.2] - 2026-03-23
 
 ### Added
+
 - External message prefix on channel-delivered transcripts -- prompt injection mitigation
 - Load `voicemode.env` for config; fix plugin path resolution
 
 ## [0.1.1] - 2026-03-23
 
 ### Added
+
 - Project context in capabilities_update (git repo name + project_path)
 - Unique device IDs per project directory (enables multi-session coexistence)
 
 ### Changed
+
 - Updated `voicemode connect login` references to `voicemode connect auth login`
 
 ## [0.1.0] - 2026-03-23
 
 ### Added
+
 - Initial release as standalone Claude Code channel plugin
 - MCP channel server for inbound voice calls via VoiceMode Connect
 - WebSocket gateway connection with Auth0 authentication and token refresh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,14 @@ All notable changes to the VoiceMode Channel plugin will be documented in this f
 ### Added
 
 - **Maildir persistence** -- inbound voice messages and outbound replies are now written to `~/.voicemode/maildir/channel/` in standard Maildir format, so conversation history survives across agent sessions (VMC-452)
-- **Conversation history MCP tools** -- `list_messages` to browse the Maildir inbox and `read_message` to read a message by filename (VMC-452)
+- **Conversation history MCP tools** -- `list_messages` to browse the Maildir inbox and `read_message` to read a message by filename (marks the message as read by default; pass `mark_read: false` to opt out) (VMC-452, VMC-490)
 - **Read/unread state tracking** -- messages move from `new/` to `cur/` when read, following the Maildir `:2,FLAGS` standard (S=Seen, R=Replied) that notmuch and neomutt read natively (VMC-490)
 - **`mark_read` MCP tool** -- mark one or more messages read in bulk, with a custom flag set for marking replied, flagged, or other states (VMC-490)
-- **Bulk body reads** -- `list_messages` now takes `include_body` (default false) and `body_max_length` (default 2000, 0 = unlimited) with a clear truncation marker, so agents can fetch many messages in one call (VMC-490)
+- **Bulk body reads** -- `list_messages` takes `include_body` (default false) and `body_max_length` (default 2000, 0 = unlimited) with a clear truncation marker, so agents can fetch many messages in one call (VMC-490)
 - **Unread filter** -- `list_messages` accepts `unread` (true/false/undefined) to filter by read state (VMC-490)
-- **Unread count in status** -- the `status` tool now reports the number of unread messages, supporting notification-append patterns (VMC-490)
+- **Unread count in status** -- the `status` tool reports the number of unread messages, supporting notification-append patterns (VMC-490)
 - **R-flag on reply** -- the `reply` tool accepts an optional `in_reply_to` filename and stamps the source message with the Replied flag (VMC-490)
 - **Persistence configuration** -- `VOICEMODE_MAILDIR_PATH` and `VOICEMODE_MAILDIR_ENABLED` environment variables control the Maildir location and whether persistence is active
-
-### Changed
-
-- **`read_message` auto-marks as read** -- default behaviour is to mark the message read on successful fetch; pass `mark_read: false` to opt out (VMC-490)
 
 ### Security
 


### PR DESCRIPTION
## Summary

Mike noticed: read_message was added in this same Unreleased section, so calling the auto-mark-as-read behaviour a 'Change' doesn't make sense -- from a user's perspective it's just how the tool works from day one.

Folded the auto-mark note into the read_message Added entry and removed the (now empty) Changed section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)