### PR TITLE
fix(release): sync package.json version in release target (VMC-466)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,4 +67,11 @@ publish: clean audit build
 
 release:
 	@claude-plugin-release
+	@node -e 'const v=require("./.claude-plugin/plugin.json").version; const fs=require("fs"); const pkg=JSON.parse(fs.readFileSync("./package.json","utf8")); if(pkg.version!==v){pkg.version=v; fs.writeFileSync("./package.json", JSON.stringify(pkg,null,2)+"\n"); console.log("Synced package.json to "+v);} else {console.log("package.json already at "+v);}'
+	@if [ -n "$$(git status --porcelain package.json)" ]; then \
+		VERSION=$$(node -p 'require("./.claude-plugin/plugin.json").version') && \
+		git add package.json && \
+		git commit -m "chore: sync package.json to $$VERSION" && \
+		git push; \
+	fi
 	$(MAKE) publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voicemode-channel",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "description": "VoiceMode Channel - inbound voice calls to Claude Code via VoiceMode Connect",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

`make release` just failed with "You cannot publish over the previously published versions: 0.2.1" because claude-plugin-release bumped plugin.json to 0.3.1 but package.json was left at 0.2.1. npm then tried to re-publish 0.2.1 and failed.

## Fix

- Bump package.json to 0.3.1 (unblocks the pending publish)
- Add a sync step to the release target that reads plugin.json, updates package.json if they diverge, and commits + pushes the sync automatically

After merge, `make publish` alone will ship 0.3.1 to npm. Future `make release` runs will keep package.json in sync automatically.

## Test plan

- [ ] Merge this PR
- [ ] Run `make publish` -- should successfully publish voicemode-channel@0.3.1
- [ ] Next `make release` run: verify package.json is auto-synced and committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)