### PR TITLE
Rename reply tool to send_message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the VoiceMode Channel plugin will be documented in this f
 
 ## [Unreleased]
 
+### Changed
+
+- **Renamed `reply` tool to `send_message`** -- better semantic naming for both humans and LLMs. The tool sends a message; the receiver decides whether to play it as TTS or show as text (VMC-494)
+
 ## [0.3.1] - 2026-04-05
 
 ## [0.3.0] - 2026-04-05
@@ -17,7 +21,7 @@ All notable changes to the VoiceMode Channel plugin will be documented in this f
 - **Bulk body reads** -- `list_messages` takes `include_body` (default false) and `body_max_length` (default 2000, 0 = unlimited) with a clear truncation marker, so agents can fetch many messages in one call (VMC-490)
 - **Unread filter** -- `list_messages` accepts `unread` (true/false/undefined) to filter by read state (VMC-490)
 - **Unread count in status** -- the `status` tool reports the number of unread messages, supporting notification-append patterns (VMC-490)
-- **R-flag on reply** -- the `reply` tool accepts an optional `in_reply_to` filename and stamps the source message with the Replied flag (VMC-490)
+- **R-flag on reply** -- the `send_message` tool accepts an optional `in_reply_to` filename and stamps the source message with the Replied flag (VMC-490)
 - **Persistence configuration** -- `VOICEMODE_MAILDIR_PATH` and `VOICEMODE_MAILDIR_ENABLED` environment variables control the Maildir location and whether persistence is active
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 A Claude Code plugin that enables inbound voice calls via [VoiceMode Connect](https://voicemode.dev).
 
-Users speak on their phone or web app, and their messages arrive in your Claude Code session as channel events. Claude responds using the reply tool, and the response is spoken aloud on the caller's device.
+Users speak on their phone or web app, and their messages arrive in your Claude Code session as channel events. Claude responds using the send_message tool, and the message is delivered to the caller's device.
 
 ![VoiceMode Connect web app showing a voice conversation with Claude Code](assets/screenshot.png)
 
 ```
 User speaks on phone/web -> VoiceMode gateway -> Channel plugin -> Claude Code
                                                                        |
-User hears TTS response  <- Channel reply tool <----------------------+
+User receives message     <- Channel send_message tool <----------------+
 ```
 
 ## Install
@@ -79,7 +79,7 @@ This plugin provides an MCP server that declares the experimental `claude/channe
 1. Connects to the VoiceMode Connect WebSocket gateway (authenticated via Auth0)
 2. Registers as a callable agent so callers can reach it
 3. Receives voice transcripts and pushes them as channel notifications
-4. Provides a `reply` tool for Claude to send responses back
+4. Provides a `send_message` tool for Claude to send responses back
 
 Channel events appear in Claude's session as:
 
@@ -99,7 +99,7 @@ Channel events appear in Claude's session as:
 **No audio on caller's device**
 
 - Confirm you're signed into [app.voicemode.dev](https://app.voicemode.dev) with the same account
-- Check that Claude is using the `reply` tool (not a plain text response)
+- Check that Claude is using the `send_message` tool (not a plain text response)
 
 **Plugin not found after install**
 
@@ -139,7 +139,7 @@ Example session:
 ```
 mcp > tools                              # List available tools
 mcp > status                             # Check connection state
-mcp > reply {"text":"hello from cli"}    # Send a voice reply
+mcp > send_message {"text":"hello from cli"}  # Send a message
 mcp > profile                            # View agent profile
 mcp > profile {"voice":"af_sky"}         # Update profile fields
 mcp > /q                                 # Quit

--- a/index.ts
+++ b/index.ts
@@ -150,8 +150,8 @@ const CHANNEL_VERSION = (() => {
 const INSTRUCTIONS = [
   'Events from VoiceMode appear as <channel source="voicemode-channel" caller="NAME">TRANSCRIPT</channel>.',
   'These are inbound voice messages from a user speaking on their phone or web app.',
-  'Respond using the voicemode-channel reply tool (NOT the converse tool from a different server).',
-  'The reply tool sends your response back through the same channel connection,',
+  'Respond using the voicemode-channel send_message tool (NOT the converse tool from a different server).',
+  'The send_message tool sends your response back through the same channel connection,',
   'keeping the conversation in the same thread on the user\'s device.',
   'Address the caller by name.',
   'Keep responses concise -- the user is listening via text-to-speech.',
@@ -197,25 +197,25 @@ function generate_message_id(): string {
 }
 
 // ---------------------------------------------------------------------------
-// MCP tool handlers (reply tool)
+// MCP tool handlers (send_message tool)
 // ---------------------------------------------------------------------------
 
 mcp.setRequestHandler(ListToolsRequestSchema, async () => {
   return {
     tools: [
       {
-        name: 'reply',
+        name: 'send_message',
         description:
-          'Send a voice reply to the user through VoiceMode. ' +
-          'Use this to respond to inbound voice channel events. ' +
-          'The reply is spoken aloud on the user\'s device via TTS. ' +
+          'Send a message to the user through VoiceMode. ' +
+          'Use this to respond to inbound voice channel events or to initiate a conversation. ' +
+          'The message is delivered to the user\'s device -- they may hear it as TTS or read it as text. ' +
           'Pass in_reply_to to mark the source message with the R (Replied) flag.',
         inputSchema: {
           type: 'object' as const,
           properties: {
             text: {
               type: 'string',
-              description: 'The message to speak to the user',
+              description: 'The message to send to the user',
             },
             voice: {
               type: 'string',
@@ -377,8 +377,8 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
     return handle_profile_tool(args as Record<string, unknown> | undefined)
   }
 
-  if (name === 'reply') {
-    return handle_reply_tool(args as Record<string, unknown> | undefined)
+  if (name === 'send_message') {
+    return handle_send_message_tool(args as Record<string, unknown> | undefined)
   }
 
   if (name === 'list_messages') {
@@ -466,10 +466,10 @@ function handle_status_tool() {
 }
 
 // ---------------------------------------------------------------------------
-// Tool handler: reply
+// Tool handler: send_message
 // ---------------------------------------------------------------------------
 
-function handle_reply_tool(args: Record<string, unknown> | undefined) {
+function handle_send_message_tool(args: Record<string, unknown> | undefined) {
   // Validate arguments
   const text = args?.text
   if (typeof text !== 'string' || text.trim().length === 0) {
@@ -512,10 +512,10 @@ function handle_reply_tool(args: Record<string, unknown> | undefined) {
     }
   }
 
-  log(`Sent reply via gateway: id=${msg_id} text="${truncate(text.trim(), 80)}"`)
+  log(`Sent message via gateway: id=${msg_id} text="${truncate(text.trim(), 80)}"`)
 
-  // Apply R (Replied) flag to the source message when reply-context is provided.
-  // Best-effort -- never break reply flow if the source file is gone.
+  // Apply R (Replied) flag to the source message when in_reply_to is provided.
+  // Best-effort -- never break send flow if the source file is gone.
   if (in_reply_to) {
     try {
       const results = mark_read([in_reply_to], 'R')
@@ -531,7 +531,7 @@ function handle_reply_tool(args: Record<string, unknown> | undefined) {
     }
   }
 
-  // Persist outbound message to Maildir (best-effort -- never break reply flow)
+  // Persist outbound message to Maildir (best-effort -- never break send flow)
   try {
     write_message({
       direction: 'outbound',
@@ -550,7 +550,7 @@ function handle_reply_tool(args: Record<string, unknown> | undefined) {
   return {
     content: [{
       type: 'text',
-      text: `Reply sent (id: ${msg_id}). Text: "${truncate(text.trim(), 120)}"`,
+      text: `Message sent (id: ${msg_id}). Text: "${truncate(text.trim(), 120)}"`,
     }],
   }
 }
@@ -840,7 +840,7 @@ function start_gateway(): void {
       ? user_id
       : undefined
 
-    // Remember caller name for outbound reply attribution
+    // Remember caller name for outbound message attribution
     last_caller_name = caller
 
     log(`Received voice event: from="${caller}" text="${truncate(safe_text.trim(), 80)}"`)


### PR DESCRIPTION
## Summary
- Renames the MCP `reply` tool to `send_message` (VMC-494)
- Updates tool description: messages are "delivered" not "spoken" -- the receiver decides presentation
- Updates README and CHANGELOG with new tool name
- No functional changes -- same WebSocket `speak` message type underneath

## Rationale
The tool sends a message; the receiver decides whether to play it as TTS or show as text. "send_message" is explicit, matches conventions (Telegram, Slack), and is unambiguous for LLMs.

## Test plan
- [ ] `make build` compiles clean
- [ ] `make shell` → `send_message {"text":"hello"}` works
- [ ] Old `reply` tool name returns "Unknown tool" error
- [ ] Channel system prompt references `send_message`

🤖 Generated with [Claude Code](https://claude.com/claude-code)