### PR TITLE
Add skill file, prefer converse over reply

### DIFF
--- a/.claude/skills/voicemode-channel.md
+++ b/.claude/skills/voicemode-channel.md
@@ -1,0 +1,45 @@
+---
+name: voicemode-channel
+description: VoiceMode Connect channel -- receive and respond to voice/text messages from users on their phone or web app
+when_to_load: When a VoiceMode Connect channel message arrives, or when the user asks about the VoiceMode channel, Connect messaging, or inbound voice calls
+---
+
+# VoiceMode Channel
+
+Bridges VoiceMode Connect to Claude Code agents. Users speak or type on their phone/web app, messages arrive here as channel notifications.
+
+## Responding to Messages
+
+**Prefer the VoiceMode Connect converse tool** (`mcp__claude_ai_VoiceMode_Connect__converse`) for voice conversations. It speaks your message AND listens for the user's reply in one call -- a full conversational turn.
+
+Use the channel `reply` tool only when:
+- The VoiceMode Connect converse tool is not available
+- You need a one-way notification (no response expected)
+- You're on a platform that doesn't support the converse MCP tool
+
+## Message Format
+
+Inbound messages arrive as:
+```
+<channel source="voicemode-channel" caller="NAME">TRANSCRIPT</channel>
+```
+
+These are from a real person speaking or typing on their device. Address them by name. Keep responses concise -- the user is listening via text-to-speech.
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `reply` | One-way voice reply (spoken via TTS on user's device) |
+| `status` | Check channel connection state and profile |
+| `profile` | Get or update agent identity (name, display name, voice, presence) |
+| `list_messages` | List recent inbound messages (Maildir) |
+| `read_message` | Read a specific message by ID |
+| `mark_read` | Mark messages as read/replied |
+
+## Key Facts
+
+- Messages queue when the agent is busy (delivered between turns)
+- The channel maintains a Maildir for message history
+- Profile changes (name, voice, presence) are broadcast to connected users
+- The agent appears as a "contact" on the user's dashboard

--- a/index.ts
+++ b/index.ts
@@ -148,13 +148,10 @@ const CHANNEL_VERSION = (() => {
 })()
 
 const INSTRUCTIONS = [
-  'Events from VoiceMode appear as <channel source="voicemode-channel" caller="NAME">TRANSCRIPT</channel>.',
-  'These are inbound voice messages from a user speaking on their phone or web app.',
-  'Respond using the voicemode-channel reply tool (NOT the converse tool from a different server).',
-  'The reply tool sends your response back through the same channel connection,',
-  'keeping the conversation in the same thread on the user\'s device.',
-  'Address the caller by name.',
-  'Keep responses concise -- the user is listening via text-to-speech.',
+  'VoiceMode Connect channel -- voice/text messages from users on their phone or web app.',
+  'Prefer the VoiceMode Connect converse tool for voice replies (speaks AND listens).',
+  'Fall back to the channel reply tool if converse is unavailable.',
+  'Full guidance in the voicemode-channel skill (.claude/skills/voicemode-channel.md).',
 ].join(' ')
 
 // ---------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "files": [
     "dist/",
+    ".claude/",
     "README.md"
   ],
   "scripts": {


### PR DESCRIPTION
## Summary
- Created `.claude/skills/voicemode-channel.md` with agent guidance for responding to Connect messages
- Key guidance: prefer VoiceMode Connect converse tool (speaks AND listens) over channel reply tool (one-way)
- Trimmed MCP INSTRUCTIONS from 7 lines to 4 -- brief identification + pointer to skill
- Updated `package.json` to include `.claude/` in npm distribution

## Why
The channel's reply tool is one-way (fire-and-forget TTS). The VoiceMode Connect converse tool does a full speak-and-listen cycle, which is the right default for voice conversations. The old INSTRUCTIONS explicitly told agents NOT to use converse -- now reversed.

Having the skill file also means MCP-only consumers (Pi, Codex) can discover the guidance even if they don't load Claude Code plugins.

## Test plan
- [ ] `make build` compiles clean
- [ ] Skill file loads when plugin is installed
- [ ] Agent uses converse tool when responding to channel messages
- [ ] Reply tool still works as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)